### PR TITLE
Fix index page to support Base URL

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,11 @@ sidebar: false
 
 <script setup>
 import { onMounted } from 'vue';
+import { withBase } from 'vitepress';
+
 onMounted(() => {
   if (typeof window !== 'undefined') {
-    window.location.href = '/installation/';
+    window.location.href = withBase('/installation/');
   }
 });
 </script>


### PR DESCRIPTION
This small fix allow to deploy docs to non-root URL.

For more info see [Base URL](https://vitepress.dev/guide/asset-handling#base-url) documentation.