### PR TITLE
Fix nginx websocket and keepalive support

### DIFF
--- a/content/integration/nginx.md
+++ b/content/integration/nginx.md
@@ -33,6 +33,14 @@ upstream rustfs-console {
 }
 
 
+map $http_upgrade $proxy_set_header_connection {
+   # If the Upgrade request header is present, also send `Connection: upgrade` upstream;
+   # otherwise send a blank Connection header instead of the default `Connection: close`,
+   # preserving upstream keepalives.
+   default "upgrade";
+   "" "";
+}
+
 server {
    listen       80;
    listen  [::]:80;
@@ -59,11 +67,10 @@ server {
       proxy_connect_timeout 300;
       # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
       proxy_http_version 1.1;
-      proxy_set_header Connection "";
       chunked_transfer_encoding off;
 
       proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
+      proxy_set_header Connection $proxy_set_header_connection;
 
 
 
@@ -99,11 +106,10 @@ server {
       proxy_connect_timeout 300;
       # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
       proxy_http_version 1.1;
-      proxy_set_header Connection "";
       chunked_transfer_encoding off;
 
       proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
+      proxy_set_header Connection $proxy_set_header_connection;
 
 
 
@@ -167,6 +173,14 @@ S3 endpoint: `s3.rustfs.dev`
 Console: `console.rustfs.dev`
 
 ~~~nginx title="/etc/nginx/conf.d/rustfs.conf (dedicated DNS)"
+map $http_upgrade $proxy_set_header_connection {
+   # If the Upgrade request header is present, also send `Connection: upgrade` upstream;
+   # otherwise send a blank Connection header instead of the default `Connection: close`,
+   # preserving upstream keepalives.
+   default "upgrade";
+   "" "";
+}
+
 # S3 API
 server {
    listen       443 ssl;
@@ -195,8 +209,10 @@ server {
       proxy_connect_timeout 300;
       # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
       proxy_http_version 1.1;
-      proxy_set_header Connection "";
       chunked_transfer_encoding off;
+
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $proxy_set_header_connection;
 
       proxy_pass http://127.0.0.1:9000;
    }
@@ -226,11 +242,10 @@ server {
       proxy_connect_timeout 300;
       # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
       proxy_http_version 1.1;
-      proxy_set_header Connection "";
       chunked_transfer_encoding off;
 
       proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
+      proxy_set_header Connection $proxy_set_header_connection;
       proxy_pass http://127.0.0.1:9001;
    }
 }

--- a/docs/integration/nginx.md
+++ b/docs/integration/nginx.md
@@ -32,6 +32,12 @@ upstream rustfs-console {
    server 127.0.0.1:9001;
 }
 
+map $http_upgrade $proxy_set_header_connection {
+   # If the Upgrade request header is present, also send a `Connection: upgrade` request header upstream,
+   # otherwise prevent the default `Connection: close` request header being sent to preserve keepalives.
+   default "upgrade";
+   "" "";
+}
 
 server {
    listen       80;
@@ -59,14 +65,10 @@ server {
       proxy_connect_timeout 300;
       # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
       proxy_http_version 1.1;
-      proxy_set_header Connection "";
       chunked_transfer_encoding off;
 
       proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
-
-
-
+      proxy_set_header Connection $proxy_set_header_connection;
 
       proxy_pass http://rustfs; # This uses the upstream directive definition to load balance
    }
@@ -99,14 +101,10 @@ server {
       proxy_connect_timeout 300;
       # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
       proxy_http_version 1.1;
-      proxy_set_header Connection "";
       chunked_transfer_encoding off;
 
       proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
-
-
-
+      proxy_set_header Connection $proxy_set_header_connection;
 
       proxy_pass http://rustfs-console; # This uses the upstream directive definition to load balance
    }
@@ -149,6 +147,13 @@ Console: `www.rustfs.dev`
 
 
 ~~~
+map $http_upgrade $proxy_set_header_connection {
+   # If the Upgrade request header is present, send a `Connection: upgrade` request header upstream,
+   # otherwise prevent the default `Connection: close` request header being sent to preserve keepalives.
+   default "upgrade";
+   "" "";
+}
+
 server {
    listen       443;
    listen  [::]:443;
@@ -175,11 +180,10 @@ server {
       proxy_connect_timeout 300;
       # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
       proxy_http_version 1.1;
-      proxy_set_header Connection "";
       chunked_transfer_encoding off;
 
       proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
+      proxy_set_header Connection $proxy_set_header_connection;
 
       proxy_pass http://127.0.0.1:9000;
    }
@@ -195,11 +199,11 @@ server {
       proxy_connect_timeout 300;
       # Default is HTTP/1, keepalive is only enabled in HTTP/1.1
       proxy_http_version 1.1;
-      proxy_set_header Connection "";
       chunked_transfer_encoding off;
 
       proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
+      proxy_set_header Connection $proxy_set_header_connection;
+
       proxy_pass http://127.0.0.1:9001; 
    }
 }


### PR DESCRIPTION
By default nginx will send a `Connection: close` request header to the upstream when proxying which breaks upstream connection keepalives and can introduce latency due to repeated upstream TCP handshakes, and port exhaustion under load due to accumulating `TIME_WAIT`/`CLOSE_WAIT` TCP sockets.

To fix upstream keepalives we configure nginx to not send the `Connection` request header upstream by setting the value to blank.

However, for websocket support, if the `Upgrade: websocket` request header is present, we must send a `Connection: upgrade` request header with it to the upstream.

An nginx `map` allows us to support both within the same `location` block.