### PR TITLE
Remove 'S3 Compatible API' empty page

### DIFF
--- a/docs/developer/api/index.md
+++ b/docs/developer/api/index.md
@@ -1,9 +1,0 @@
----
-title: "English Documentation"
-description: "This documentation is being translated from Chinese to English"
----
-
-# English Documentation
-
-This section contains the RustFS documentation translated into English.
-

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -256,10 +256,6 @@ export const sidebar = [
         ]
       },
       {
-        text: 'S3 Compatible API',
-        link: '/developer/api'
-      },
-      {
         text: 'Open Source License',
         link: '/developer/license'
       }


### PR DESCRIPTION
* Removed the `docs/developer/api/index.md` empty file.
* Removed the "S3 Compatible API" link from the developer section of the documentation sidebar in `docs/sidebar.ts`.