### PR TITLE
fix: fix outdated config initialization (EndpointResolver) in Go SDK documentation 

### DIFF
--- a/docs/developer/sdk/go.md
+++ b/docs/developer/sdk/go.md
@@ -30,16 +30,12 @@ if access_key_id == "" || secret_access_key == "" || region == "" || endpoint ==
 // build aws.Config
 cfg := aws.Config{
     Region: region,
-    EndpointResolver: aws.EndpointResolverFunc(func(service, region string) (aws.Endpoint, error) {
-        return aws.Endpoint{
-            URL: endpoint,
-        }, nil
-    }),
     Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(access_key_id, secret_access_key, "")),
 }
 
 // build S3 client
 client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+    o.BaseEndpoint = aws.String(endpoint)
     o.UsePathStyle = true
 })
 ```


### PR DESCRIPTION
This pull request updates the Go SDK documentation for configuring an S3 client, focusing on how the endpoint is set in the AWS configuration. Changed the way the custom endpoint is specified when creating the S3 client to the not deprecated one. (See [here](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-endpoints.html#migration))

<img width="876" height="304" alt="Code 2026-03-16 12 49 05" src="https://github.com/user-attachments/assets/f97a3398-940f-4b36-9dd2-8225c0124e26" />
