### PR TITLE
docs: fill-in credential placeholders + secure-credential hints

### DIFF
--- a/docs/developer/sdk/java.md
+++ b/docs/developer/sdk/java.md
@@ -67,6 +67,7 @@ public class RustfsS3Example {
  .region(Region.US_EAST_1) // RustFS does not validate regions
  .credentialsProvider(
  StaticCredentialsProvider.create(
+ // Use a unique access key and a strong secret (e.g. openssl rand -base64 24)
  AwsBasicCredentials.create("<your-access-key>", "<your-secret-key>")
  )
  )
@@ -171,6 +172,7 @@ S3Presigner presigner = S3Presigner.builder()
  .region(Region.US_EAST_1)
  .credentialsProvider(
  StaticCredentialsProvider.create(
+ // Use a unique access key and a strong secret (e.g. openssl rand -base64 24)
  AwsBasicCredentials.create("<your-access-key>", "<your-secret-key>")
  )
  )

--- a/docs/developer/sdk/java.md
+++ b/docs/developer/sdk/java.md
@@ -67,7 +67,7 @@ public class RustfsS3Example {
  .region(Region.US_EAST_1) // RustFS does not validate regions
  .credentialsProvider(
  StaticCredentialsProvider.create(
- AwsBasicCredentials.create("rustfsadmin", "change-your-password")
+ AwsBasicCredentials.create("<your-access-key>", "<your-secret-key>")
  )
  )
  .forcePathStyle(true) // Required for RustFS compatibility
@@ -171,7 +171,7 @@ S3Presigner presigner = S3Presigner.builder()
  .region(Region.US_EAST_1)
  .credentialsProvider(
  StaticCredentialsProvider.create(
- AwsBasicCredentials.create("rustfsadmin", "change-your-password")
+ AwsBasicCredentials.create("<your-access-key>", "<your-secret-key>")
  )
  )
  .build();

--- a/docs/developer/sdk/javascript.md
+++ b/docs/developer/sdk/javascript.md
@@ -25,8 +25,8 @@ Assume the RustFS instance is deployed as follows:
 
 ```
 Endpoint: http://192.168.1.100:9000
-Access Key: rustfsadmin
-Secret Key: change-your-password
+Access Key: <your-access-key>
+Secret Key: <your-secret-key>
 ```
 
 ---
@@ -41,8 +41,8 @@ const s3 = new S3Client({
  endpoint: "http://192.168.1.100:9000", // RustFS endpoint
  region: "us-east-1", // Any value is accepted
  credentials: {
- accessKeyId: "rustfsadmin",
- secretAccessKey: "change-your-password",
+ accessKeyId: "<your-access-key>",
+ secretAccessKey: "<your-secret-key>",
  },
  forcePathStyle: true, // Must be enabled for RustFS compatibility
  requestHandler: new NodeHttpHandler({

--- a/docs/developer/sdk/javascript.md
+++ b/docs/developer/sdk/javascript.md
@@ -41,6 +41,7 @@ const s3 = new S3Client({
  endpoint: "http://192.168.1.100:9000", // RustFS endpoint
  region: "us-east-1", // Any value is accepted
  credentials: {
+ // Use a unique access key and a strong secret (e.g. openssl rand -base64 24)
  accessKeyId: "<your-access-key>",
  secretAccessKey: "<your-secret-key>",
  },

--- a/docs/developer/sdk/python.md
+++ b/docs/developer/sdk/python.md
@@ -54,6 +54,7 @@ from botocore.client import Config
 s3 = boto3.client(
  's3',
  endpoint_url='http://192.168.1.100:9000',
+ # Use a unique access key and a strong secret (e.g. openssl rand -base64 24)
  aws_access_key_id='<your-access-key>',
  aws_secret_access_key='<your-secret-key>',
  config=Config(signature_version='s3v4'),

--- a/docs/developer/sdk/python.md
+++ b/docs/developer/sdk/python.md
@@ -27,8 +27,8 @@ Assume RustFS is deployed as follows:
 
 ```
 Endpoint: http://192.168.1.100:9000
-AccessKey: rustfsadmin
-SecretKey: change-your-password
+AccessKey: <your-access-key>
+SecretKey: <your-secret-key>
 ```
 
 ### 2.2 Install Boto3
@@ -54,8 +54,8 @@ from botocore.client import Config
 s3 = boto3.client(
  's3',
  endpoint_url='http://192.168.1.100:9000',
- aws_access_key_id='rustfsadmin',
- aws_secret_access_key='change-your-password',
+ aws_access_key_id='<your-access-key>',
+ aws_secret_access_key='<your-secret-key>',
  config=Config(signature_version='s3v4'),
  region_name='us-east-1'
 )

--- a/docs/installation/checklists/security-checklists.md
+++ b/docs/installation/checklists/security-checklists.md
@@ -29,7 +29,7 @@ description: "Security checklist for enterprise deployments."
 ## 3. Credential Protection
 
 - **Change Default Credentials**
- Change default accounts (e.g., `rustfsadmin`) to strong, random passwords immediately after initialization.
+ Never keep the example placeholders (`<your-access-key>` / `<your-secret-key>`) in production. Set a unique access key and a strong, random secret — e.g. generate one with `openssl rand -base64 24` — immediately after initialization.
 
 - **Secure Storage**
  Do not hardcode credentials. Use environment variables or secrets management systems (e.g., Kubernetes Secrets).

--- a/docs/installation/docker/index.md
+++ b/docs/installation/docker/index.md
@@ -70,16 +70,16 @@ docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v /mnt/rustfs/data:/data \
-  -e RUSTFS_ACCESS_KEY=rustfsadmin \
-  -e RUSTFS_SECRET_KEY=change-your-password \
+  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
+  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_SERVER_DOMAINS=example.com \
   rustfs/rustfs:latest \
   --address :9000 \
   --console-enable \
   --server-domains example.com \
-  --access-key rustfsadmin \
-  --secret-key change-your-password \
+  --access-key "<your-access-key>" \
+  --secret-key "<your-secret-key>" \
   /data
 ```
 
@@ -89,8 +89,8 @@ docker run -d \
    ```bash
    -e RUSTFS_ADDRESS=:9000 \
    -e RUSTFS_SERVER_DOMAINS=example.com \
-   -e RUSTFS_ACCESS_KEY=rustfsadmin \
-   -e RUSTFS_SECRET_KEY=change-your-password \
+   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
+   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
    -e RUSTFS_CONSOLE_ENABLE=true \
    ```
 
@@ -98,8 +98,8 @@ docker run -d \
    ```
    --address :9000 \
    --server-domains example.com \
-   --access-key rustfsadmin \
-   --secret-key change-your-password \
+   --access-key "<your-access-key>" \
+   --secret-key "<your-secret-key>" \
    --console-enable \
    ```
 
@@ -136,11 +136,11 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
-     -e RUSTFS_ACCESS_KEY=rustfsadmin \
-     -e RUSTFS_SECRET_KEY=change-your-password \
+     -e RUSTFS_ACCESS_KEY="<your-access-key>" \
+     -e RUSTFS_SECRET_KEY="<your-secret-key>" \
      rustfs/rustfs:latest \
-     --access-key rustfsadmin \
-     --secret-key change-your-password \
+     --access-key "<your-access-key>" \
+     --secret-key "<your-secret-key>" \
      /data
    ```
 
@@ -233,7 +233,7 @@ CONTAINER ID   IMAGE                                             COMMAND        
 e07121ecdd39   rustfs/rustfs:latest                              "/entrypoint.sh rust…"   2 seconds ago   Up 1 second (health: starting)   0.0.0.0:9000-9001->9000-9001/tcp, :::9000-9001->9000-9001/tcp   rustfs-server
 ```
 
-Whether you start only the `rustfs-server` or together with observability services, you can access the RustFS instance via `http://localhost:9000` using the access key and secret key you configured above (in these examples, username `rustfsadmin` and password `change-your-password`). Be sure to replace the password with a strong secret of your own.
+Whether you start only the `rustfs-server` or together with observability services, you can access the RustFS instance via `http://localhost:9000` using the access key and secret key you configured above (the `<your-access-key>` / `<your-secret-key>` placeholders). Generate a strong secret with, for example, `openssl rand -base64 24`, and never ship the placeholder values to production.
 
 ## 4. Verification and Access
 
@@ -250,7 +250,7 @@ Whether you start only the `rustfs-server` or together with observability servic
  Use `mc` or other S3 clients:
 
  ```bash
- mc alias set rustfs http://localhost:9000 rustfsadmin change-your-password
+ mc alias set rustfs http://localhost:9000 "<your-access-key>" "<your-secret-key>"
  mc mb rustfs/mybucket
  mc ls rustfs
  ```
@@ -268,8 +268,8 @@ docker run -d \
   --name rustfs \
   --network host \
   -v /mnt/rustfs/data:/data \
-  -e RUSTFS_ACCESS_KEY=rustfsadmin \
-  -e RUSTFS_SECRET_KEY=change-your-password \
+  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
+  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_VOLUMES="http://node{1...4}:9000/data/rustfs{0...3}" \
   rustfs/rustfs:latest

--- a/docs/installation/docker/index.md
+++ b/docs/installation/docker/index.md
@@ -65,6 +65,7 @@ Parameter descriptions:
 ### Complete Parameter Configuration Example
 
 ```bash
+# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
 docker run -d \
   --name rustfs_container \
   -p 9000:9000 \
@@ -87,6 +88,7 @@ docker run -d \
 
 1. **Environment Variable Method** (Recommended):
    ```bash
+   # Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
    -e RUSTFS_ADDRESS=:9000 \
    -e RUSTFS_SERVER_DOMAINS=example.com \
    -e RUSTFS_ACCESS_KEY="<your-access-key>" \
@@ -96,6 +98,7 @@ docker run -d \
 
 2. **Command Line Parameter Method**:
    ```
+   # Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
    --address :9000 \
    --server-domains example.com \
    --access-key "<your-access-key>" \
@@ -132,6 +135,7 @@ docker run -d \
 
 3. **Custom Authentication Keys**:
    ```bash
+   # Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
    docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
@@ -250,6 +254,7 @@ Whether you start only the `rustfs-server` or together with observability servic
  Use `mc` or other S3 clients:
 
  ```bash
+ # Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
  mc alias set rustfs http://localhost:9000 "<your-access-key>" "<your-secret-key>"
  mc mb rustfs/mybucket
  mc ls rustfs
@@ -264,6 +269,7 @@ Dockers default bridge networking does not support multi-node deployments. Use `
 Run the following on **each node**
 
 ```bash
+# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
 docker run -d \
   --name rustfs \
   --network host \

--- a/docs/installation/linux/multiple-node-multiple-disk.md
+++ b/docs/installation/linux/multiple-node-multiple-disk.md
@@ -230,8 +230,9 @@ mv rustfs /usr/local/bin/
 ```bash
 # Multiple node multiple disk mode
 sudo tee /etc/default/rustfs <<EOF
-RUSTFS_ACCESS_KEY=rustfsadmin
-RUSTFS_SECRET_KEY=change-your-password
+# Replace the placeholders below; generate a strong secret, e.g. openssl rand -base64 24
+RUSTFS_ACCESS_KEY=<your-access-key>
+RUSTFS_SECRET_KEY=<your-secret-key>
 RUSTFS_VOLUMES="http://node{1...4}:9000/data/rustfs{0...3}"
 RUSTFS_ADDRESS=":9000"
 RUSTFS_CONSOLE_ENABLE=true

--- a/docs/installation/linux/multiple-node-multiple-disk.md
+++ b/docs/installation/linux/multiple-node-multiple-disk.md
@@ -230,7 +230,7 @@ mv rustfs /usr/local/bin/
 ```bash
 # Multiple node multiple disk mode
 sudo tee /etc/default/rustfs <<EOF
-# Replace the placeholders below; generate a strong secret, e.g. openssl rand -base64 24
+# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 RUSTFS_VOLUMES="http://node{1...4}:9000/data/rustfs{0...3}"

--- a/docs/installation/linux/single-node-multiple-disk.md
+++ b/docs/installation/linux/single-node-multiple-disk.md
@@ -205,7 +205,7 @@ mv rustfs /usr/local/bin/
 ```bash
 # Single node multiple disk mode
 sudo tee /etc/default/rustfs <<EOF
-# Replace the placeholders below; generate a strong secret, e.g. openssl rand -base64 24
+# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 RUSTFS_VOLUMES="/data/rustfs{0...3}"

--- a/docs/installation/linux/single-node-multiple-disk.md
+++ b/docs/installation/linux/single-node-multiple-disk.md
@@ -205,8 +205,9 @@ mv rustfs /usr/local/bin/
 ```bash
 # Single node multiple disk mode
 sudo tee /etc/default/rustfs <<EOF
-RUSTFS_ACCESS_KEY=rustfsadmin
-RUSTFS_SECRET_KEY=change-your-password
+# Replace the placeholders below; generate a strong secret, e.g. openssl rand -base64 24
+RUSTFS_ACCESS_KEY=<your-access-key>
+RUSTFS_SECRET_KEY=<your-secret-key>
 RUSTFS_VOLUMES="/data/rustfs{0...3}"
 RUSTFS_ADDRESS=":9000"
 RUSTFS_CONSOLE_ENABLE=true

--- a/docs/installation/linux/single-node-single-disk.md
+++ b/docs/installation/linux/single-node-single-disk.md
@@ -203,7 +203,7 @@ mv rustfs /usr/local/bin/
 ```bash
 # Single node single disk mode
 sudo tee /etc/default/rustfs <<EOF
-# Replace the placeholders below; generate a strong secret, e.g. openssl rand -base64 24
+# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 RUSTFS_VOLUMES="/data/rustfs0"

--- a/docs/installation/linux/single-node-single-disk.md
+++ b/docs/installation/linux/single-node-single-disk.md
@@ -203,8 +203,9 @@ mv rustfs /usr/local/bin/
 ```bash
 # Single node single disk mode
 sudo tee /etc/default/rustfs <<EOF
-RUSTFS_ACCESS_KEY=rustfsadmin
-RUSTFS_SECRET_KEY=change-your-password
+# Replace the placeholders below; generate a strong secret, e.g. openssl rand -base64 24
+RUSTFS_ACCESS_KEY=<your-access-key>
+RUSTFS_SECRET_KEY=<your-secret-key>
 RUSTFS_VOLUMES="/data/rustfs0"
 RUSTFS_ADDRESS=":9000"
 RUSTFS_CONSOLE_ENABLE=true

--- a/docs/upgrade-scale/availability-and-resiliency.md
+++ b/docs/upgrade-scale/availability-and-resiliency.md
@@ -83,8 +83,8 @@ mv rustfs /usr/local/bin/
 # Create configuration file (/etc/default/rustfs)
 # Please replace <Your RustFS admin username> and <Secure password of your RustFS admin> with yours values!
 cat <<EOF > /etc/default/rustfs
-RUSTFS_ACCESS_KEY=<Your RustFS admin username> # e.g. rustfsadmin
-RUSTFS_SECRET_KEY=<Secure password of your RustFS admin> # e.g. change-your-password
+RUSTFS_ACCESS_KEY=<Your RustFS admin username> # e.g. admin
+RUSTFS_SECRET_KEY=<Secure password of your RustFS admin> # e.g. output of: openssl rand -base64 24
 RUSTFS_VOLUMES="http://node-{1...4}:9000/data/rustfs{0...3} http://node-{5...8}:9000/data/rustfs{0...7}" # add new storage pool to the existing
 RUSTFS_ADDRESS=":9000"
 RUSTFS_CONSOLE_ADDRESS=":9001"


### PR DESCRIPTION
Follow-up to the merged PR that introduced the `change-your-password` example value. That value is runnable-but-weak; this PR replaces it (and the remaining example credentials) with **fill-in placeholders** and adds a secure-credential reminder at every command.

## Changes (2 commits)

1. **Fill-in placeholders** — replace runnable example credentials with `<your-access-key>` / `<your-secret-key>` so users must substitute their own values before anything runs.
   - Both access key and secret key are placeholders now.
   - Shell / SDK snippets: placeholders are **quoted** (`"<your-secret-key>"`) so `<`/`>` and spaces aren't interpreted as shell redirection.
   - Heredoc env files / compose: bare placeholders (matches the existing `/etc/default/rustfs` style).

2. **Per-command hint** — every credential-bearing command/code block carries an inline reminder to use a unique access key and a strong, random secret (`openssl rand -base64 24`). Comments sit at the top of shell blocks (never mid backslash-continuation) and beside the credential lines in YAML/SDK snippets.

## Why

A working default like `change-your-password` still ships a guessable credential if copy-pasted (cf. the `minioadmin/minioadmin` problem scanners actively probe). Placeholders force substitution; the hints point users at generating a strong secret.

Placeholder text and guidance only — no functional behavior change. Mirrored across both docs sites.
