### PR TITLE
docs: P0 — fix factual errors, dangerous ops guidance, leftover test content

### DIFF
--- a/content/concepts/limit.md
+++ b/content/concepts/limit.md
@@ -11,7 +11,7 @@ description: "RustFS is a simple, efficient, distributed object storage. It is f
 | --------------------- | ---------------------------------- |
 | Maximum object size | 5 TiB |
 | Minimum object size | 0 B |
-| Maximum object size for single PUT operation | Non-multipart upload: 500 GiB; Multipart upload: 5 TiB |
+| Maximum object size for single PUT operation | Non-multipart upload: 5 GiB; Multipart upload: 5 TiB |
 | Maximum number of parts per upload | 10,000 |
 | Part size range | 5 MiB to 5 GiB; last part can be 0 B to 5 GiB |
 | Maximum number of parts returned per list parts request | 10,000 |
@@ -20,7 +20,7 @@ description: "RustFS is a simple, efficient, distributed object storage. It is f
 | Maximum length of bucket name | 63 characters |
 | Maximum length of object name | 1024 characters |
 | Maximum length of each `/` separated object name segment | 255 characters |
-| Maximum number of versions per single object | 10,000 (configurable) |
+| Maximum number of versions per single object | 10,000 |
 
 ---
 
@@ -35,8 +35,8 @@ description: "RustFS is a simple, efficient, distributed object storage. It is f
 | When server count is 1, minimum number of drives per server | 1 (for single-node single-drive deployment, cannot provide additional reliability or availability) |
 | When server count is 2 or more, minimum number of drives per server | 1 |
 | Maximum number of drives per server | No hard limit |
-| Read quorum count | N/2 |
-| Write quorum count | (N/2) + 1 |
+| Read quorum count | N − M (the number of data shards, where M is the parity shard count) |
+| Write quorum count | N − M; when data and parity counts are equal, N − M + 1 |
 
 ---
 

--- a/content/concepts/principle/erasure-coding.md
+++ b/content/concepts/principle/erasure-coding.md
@@ -108,7 +108,7 @@ fn split_data(data: &[u8], k: usize) -> Vec<Shard> {
 }
 ```
 - Dynamic shard size adjustment (64 KB-4 MB)
-- Hash checksum using Blake3 algorithm
+- Streaming shard checksums using the HighwayHash256 algorithm for bitrot detection
 
 ### 4.2 Parallel Encoding Optimization
 ```rust

--- a/content/deep/nested/test-deep.md
+++ b/content/deep/nested/test-deep.md
@@ -1,6 +1,0 @@
----
-title: "Deep Test File"
-description: "This is a deeply nested test file."
----
-
-This is a deeply nested test file.

--- a/content/developer/mcp.md
+++ b/content/developer/mcp.md
@@ -20,6 +20,12 @@ The Model Context Protocol is an open standard that enables AI applications to e
 
 ## 🔧 Installation
 
+:::warning[Build instructions may be outdated]
+
+The `rustfs-mcp` crate is no longer part of the current `rustfs/rustfs` main branch, so the build commands below may fail against a fresh clone. Check the [RustFS GitHub organization](https://github.com/rustfs) for the MCP server's current location before building from source.
+
+:::
+
 ### Prerequisites
 
 - Rust 1.75+ (for building from source)
@@ -126,7 +132,7 @@ rustfs-mcp --log-level debug --region us-west-2
 
 ```bash
 # Clone RustFS repository code
-git clone git@github.com:rustfs/rustfs.git
+git clone https://github.com/rustfs/rustfs.git
 
 # Build Docker image
 docker build -f crates/mcp/Dockerfile -t rustfs/rustfs-mcp .

--- a/content/features/encryption/index.md
+++ b/content/features/encryption/index.md
@@ -1,9 +1,7 @@
 ---
-title: "Infrastructure for Large-Scale Data"
-description: "RustFS is designed for scale—technical, operational, and economic."
+title: "Data Encryption"
+description: "Server-side encryption in RustFS with SSE-S3 and SSE-C, designed to minimize performance overhead."
 ---
-
-RustFS is designed for scale—technical, operational, and economic.
 
 In the object storage field, robust encryption is a fundamental requirement for enterprise storage. RustFS provides more functionality through the highest level of encryption and extensive optimizations, minimizing the performance overhead typically associated with storage encryption operations.
 

--- a/content/features/logging/index.md
+++ b/content/features/logging/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Logging and Auditing"
-description: "Metrics and logging are crucial for system health. RustFS provides robust monitoring and observability through detailed storage performance monitoring,…"
+description: "RustFS observability: OpenTelemetry metrics, audit logging, and event notifications to external targets."
 ---
 
 Metrics and logging are crucial for system health. RustFS provides robust monitoring and observability through detailed storage performance monitoring, metrics, and logging.
@@ -17,29 +17,24 @@ Records detailed log information for every operation, supporting audit trails.
 
 ## Metrics Monitoring
 
-RustFS exports a wide range of fine-grained hardware and software metrics through Prometheus-compatible metrics endpoints. RustFS includes a storage monitoring dashboard that uses Grafana to visualize collected metrics.
+RustFS collects a wide range of fine-grained hardware and software metrics and exports them over OTLP (the OpenTelemetry Protocol, configured via `RUSTFS_OBS_ENDPOINT`). Deploy an OpenTelemetry Collector to forward these metrics to Prometheus, Grafana, or any OTLP-compatible backend. The upstream [`docker-compose.yml`](https://github.com/rustfs/rustfs/blob/main/docker-compose.yml) ships a ready-made observability profile with OpenTelemetry Collector, Prometheus, Grafana, and Jaeger.
 
-The RustFS Kubernetes Operator can automatically deploy, configure, and manage Prometheus deployments and metrics collection for each tenant. Organizations can also point their own Prometheus systems to each tenant for centralized monitoring.
-
-RustFS also provides a health check endpoint for probing node and cluster liveness.
+RustFS also provides health check endpoints (`/health` and `/health/ready`) for probing node and cluster liveness.
 
 ## Audit Logs
 
-Audit logging generates logs for every cluster operation. Each operation generates an audit log containing a unique ID and detailed information about the client, object, bucket, and metadata. RustFS writes log data to configured HTTP/HTTPS webhook endpoints.
+Audit logging generates logs for every cluster operation. Each operation generates an audit log containing a unique ID and detailed information about the client, object, bucket, and metadata. RustFS writes audit data to configured targets such as HTTP/HTTPS webhook endpoints and Kafka (`RUSTFS_AUDIT_*` environment variables).
 
-RustFS supports configuring audit logs through the RustFS Console UI and the `mc` command-line tool. For Kubernetes environments, the RustFS Operator automatically configures the console with LogSearch integration.
-
-RustFS Lambda notifications provide additional logging support. RustFS can automatically send bucket and object events to third-party applications (RabbitMQ, Kafka, Elasticsearch) for event-driven processing.
-
-RustFS also supports real-time tracing of HTTP/S operations through the RustFS Console and `mc admin trace`.
+RustFS event notifications provide additional logging support: bucket and object events can be pushed automatically to third-party systems (for example RabbitMQ via AMQP, Kafka, or a webhook) for event-driven processing.
 
 ## Architecture
 
-RustFS does not natively expose metrics via Prometheus-compatible HTTP(S) endpoints for direct scraping. To integrate with Prometheus, please deploy an OpenTelemetry Collector to gather metrics from RustFS and forward them to your Prometheus backend. The RustFS Kubernetes Operator deploys an independent Prometheus service for each pre-configured RustFS tenant.
+RustFS does not natively expose metrics via Prometheus-compatible HTTP(S) endpoints for direct scraping. To integrate with Prometheus, deploy an OpenTelemetry Collector to gather metrics from RustFS and forward them to your Prometheus backend.
 
 ```mermaid
 flowchart TD
   RUSTFS["RustFS Object Storage"]
+  OTEL["OpenTelemetry Collector"]
   subgraph PROM["Prometheus"]
     AM[Alertmanager]
     QA["Query API"]
@@ -49,7 +44,8 @@ flowchart TD
   AR["Alert Response"]
   VA["Visualization / Analytics"]
   AB["Archival / Backup"]
-  RUSTFS -->|metrics endpoint| PROM
+  RUSTFS -->|OTLP| OTEL
+  OTEL --> PROM
   PROM --> AR
   PROM --> VA
   PROM --> AB
@@ -57,11 +53,11 @@ flowchart TD
   classDef svc fill:#eef2ff,stroke:#6366f1,stroke-width:2px,color:#1e293b;
   classDef accent fill:#fae8ff,stroke:#c026d3,stroke-width:2px,color:#1e293b;
   class RUSTFS server
-  class AM,QA,RRW,WH svc
+  class OTEL,AM,QA,RRW,WH svc
   class AR,VA,AB accent
 ```
 
-RustFS Lambda notifications automatically push event notifications to supported target services. Administrators can define bucket-level notification rules.
+RustFS event notifications automatically push bucket and object events to supported target services. Administrators can define bucket-level notification rules.
 
 ```mermaid
 flowchart LR
@@ -71,18 +67,17 @@ flowchart LR
     BK["Backup / Archival"]
     BS["Block Storage"]
   end
-  TENANT["RustFS Tenant"]
+  TENANT["RustFS Cluster"]
   subgraph Targets["Notification Targets"]
-    ES[ElasticSearch]
-    PG[PostgreSQL]
+    WH[Webhooks]
     KAFKA[Kafka]
     AMQP[AMQP]
     MQTT[MQTT]
     RED[Redis]
     NATS[NATS]
+    PULSAR[Pulsar]
     MYSQL[MySQL]
-    WH[Webhooks]
-    NSQ[NSQ]
+    PG[PostgreSQL]
   end
   Clients <-->|S3 operations| TENANT
   TENANT -->|events| Targets
@@ -91,19 +86,19 @@ flowchart LR
   classDef accent fill:#fae8ff,stroke:#c026d3,stroke-width:2px,color:#1e293b;
   class IOT,WEB,BK,BS server
   class TENANT svc
-  class ES,PG,KAFKA,AMQP,MQTT,RED,NATS,MYSQL,WH,NSQ accent
+  class WH,KAFKA,AMQP,MQTT,RED,NATS,PULSAR,MYSQL,PG accent
 ```
 
 ## Requirements
 
 ### For Metrics
 
-Use Prometheus or the Kubernetes Operator to automatically deploy/configure for each tenant.
+Deploy an OpenTelemetry Collector and point `RUSTFS_OBS_ENDPOINT` at it; visualize with Prometheus and Grafana (see the upstream observability compose profile).
 
-### For Log Search
+### For Audit Logs
 
-BYO PostgreSQL *or* use Kubernetes Operator to automatically deploy/configure for each tenant.
+Configure one or more audit targets (webhook, Kafka) via `RUSTFS_AUDIT_*` environment variables.
 
-### For Logs
+### For Event Notifications
 
-Support for third-party notification targets.
+Configure bucket notification rules toward the supported targets: webhook, Kafka, AMQP, MQTT, Redis, NATS, Pulsar, MySQL, or PostgreSQL.

--- a/content/installation/checklists/network-checklists.md
+++ b/content/installation/checklists/network-checklists.md
@@ -65,12 +65,11 @@ net.ipv4.tcp_slow_start_after_idle = 0
 
 ### Firewall
 
-```bash
+```text
 # Necessary open ports
-- TCP 443 (HTTPS API)
-- TCP 9000 (S3 compatible interface)
-- TCP 7946 (Serf node communication)
-- UDP 4789 (VxLAN tunnel)
+- TCP 9000 (S3 API; also used for internal node-to-node communication)
+- TCP 9001 (RustFS Console)
+- TCP 443 (only if you terminate HTTPS on a reverse proxy / load balancer)
 ```
 
 ### Access Control
@@ -85,7 +84,7 @@ net.ipv4.tcp_slow_start_after_idle = 0
 
 ### Benchmarks
 
-1. Inter-node latency: `iperf3 -s 8972 <target IP>`
+1. Inter-node latency: `ping -c 20 <target IP>` (run `iperf3 -s` on the target first for throughput tests)
 2. Cross-rack bandwidth: `iperf3 -c <target IP> -P 8 -t 30`
 3. Failover: Randomly disconnect core links to observe recovery time.
 

--- a/content/installation/checklists/security-checklists.md
+++ b/content/installation/checklists/security-checklists.md
@@ -49,7 +49,7 @@ description: "Security checklist for enterprise deployments."
 ## API Security
 
 - **Restrict Network Access**
- Restrict access to the S3 API (port 9000) and Console (port 9090) using firewalls or security groups.
+ Restrict access to the S3 API (port 9000) and Console (port 9001) using firewalls or security groups.
 
 - **Network Isolation**
  Use reverse proxies (e.g., Nginx) instead of exposing storage nodes directly.

--- a/content/installation/checklists/software-checklists.md
+++ b/content/installation/checklists/software-checklists.md
@@ -8,12 +8,12 @@ Ensure the following requirements are met before deployment.
 ## OS Requirements
 
 - **Operating System**: Use LTS versions (Ubuntu 20.04+, RHEL 8/9).
-- **Kernel**: Linux 5.x+ is recommended for `io_uring` support.
+- **Kernel**: Linux 5.x+ is recommended.
 - **CPU & Memory**: x86_64 or ARM. Minimum 2 GB RAM for testing, 64 GB+ for production.
 - **Disable Interfering Services**: Disable file indexing and auditing services (e.g., `mlocate`, `auditd`, antivirus) to prevent I/O interference.
 
 > **Why Linux 5.x+?**
-> RustFS leverages **io_uring** for high-performance asynchronous I/O, which is mature in Linux 5.10+.
+> Modern LTS kernels bring mature async I/O and filesystem improvements. RustFS also offers an optional `io_uring` read path (`RUSTFS_IO_URING_READ_ENABLE`, disabled by default), which requires Linux 5.10+ to be effective.
 
 ## Binary Deployment
 

--- a/content/installation/linux/index.md
+++ b/content/installation/linux/index.md
@@ -6,7 +6,7 @@ description: "RustFS is an object storage solution, open-source distributed obje
 # What is RustFS?
 
 RustFS is a simple, efficient, distributed object storage system, well suited for replacing MinIO and object storage scenarios for AI training and inference.
-Additionally, RustFS is an efficient, open-source, free object storage solution. It is 100% S3 protocol compatible and open-source software released under the Apache 2.0 license. RustFS is written in Rust, leveraging its industry-leading memory safety and zero-cost abstractions for high-performance storage. RustFS is a commercial-friendly distributed object storage product developed and contributed to by excellent engineers worldwide. RustFS can replace many object storage products with unfriendly open-source licenses.
+Additionally, RustFS is an efficient, open-source, free object storage solution. It is S3-compatible open-source software released under the Apache 2.0 license. RustFS is written in Rust, leveraging its industry-leading memory safety and zero-cost abstractions for high-performance storage. RustFS is a commercial-friendly distributed object storage product developed and contributed to by excellent engineers worldwide. RustFS can replace many object storage products with unfriendly open-source licenses.
 
 RustFS is about to transition from commercial applications to formal open-source release globally, helping the world reduce storage costs and improve data security.
 
@@ -29,11 +29,11 @@ CPU architecture support: X86, ARM, and various other CPU architectures.
 
 ## RustFS Features
 
-- **S3 Compatible**: 100% S3 protocol compatible, excellent compatibility with big data, data lakes, backup software, image processing software, and industrial production software;
+- **S3 Compatible**: S3-compatible (see the [compatibility matrix](../../features/s3-compatibility/index.md)), working out of the box with big data, data lakes, backup software, image processing software, and industrial production software;
 - **Distributed**: RustFS is a distributed object storage, therefore, RustFS can meet various needs;
 - **Commercial-Friendly**: RustFS is 100% open-source software and released under Apache v2.0 license, therefore, RustFS is commercial-friendly;
 - **Fast**: The performance of Rust development language is infinitely close to C language speed. Therefore, RustFS performance is very strong;
-- **Secure**: RustFS is written in memory-safe language Rust, therefore, RustFS is 100% secure;
+- **Secure**: RustFS is written in Rust, whose memory safety eliminates entire classes of common storage-security vulnerabilities;
 - **Cross-Platform**: RustFS works on Windows, macOS, and Linux;
 - **Extensible**: RustFS supports custom plugins, therefore, RustFS can meet various needs;
 - **Customizable**: Due to open-source characteristics, you can customize various plugins, therefore, RustFS can meet various needs;

--- a/content/installation/linux/multiple-node-multiple-disk.md
+++ b/content/installation/linux/multiple-node-multiple-disk.md
@@ -74,10 +74,11 @@ systemctl stop firewalld
 systemctl disable firewalld
 ```
 
-Or allow RustFS port 9000:
+Or allow the RustFS ports — 9000 (S3 API) and 9001 (Console):
 
 ```bash
 firewall-cmd --zone=public --add-port=9000/tcp --permanent
+firewall-cmd --zone=public --add-port=9001/tcp --permanent
 firewall-cmd --reload
 ```
 
@@ -297,7 +298,8 @@ RestartSec=10s
 OOMScoreAdjust=-1000
 SendSIGKILL=no
 
-TimeoutStartSec=30s
+# RustFS reports READY only after storage and peer checks pass; allow up to 120s.
+TimeoutStartSec=120s
 TimeoutStopSec=30s
 
 NoNewPrivileges=true

--- a/content/installation/linux/single-node-multiple-disk.md
+++ b/content/installation/linux/single-node-multiple-disk.md
@@ -66,10 +66,11 @@ systemctl stop firewalld
 systemctl disable firewalld
 ```
 
-Or allow RustFS port 9000:
+Or allow the RustFS ports — 9000 (S3 API) and 9001 (Console):
 
 ```bash
 firewall-cmd --zone=public --add-port=9000/tcp --permanent
+firewall-cmd --zone=public --add-port=9001/tcp --permanent
 firewall-cmd --reload
 ```
 
@@ -265,7 +266,8 @@ RestartSec=10s
 OOMScoreAdjust=-1000
 SendSIGKILL=no
 
-TimeoutStartSec=30s
+# RustFS reports READY only after storage and peer checks pass; allow up to 120s.
+TimeoutStartSec=120s
 TimeoutStopSec=30s
 
 NoNewPrivileges=true

--- a/content/installation/linux/single-node-single-disk.md
+++ b/content/installation/linux/single-node-single-disk.md
@@ -64,10 +64,11 @@ systemctl stop firewalld
 systemctl disable firewalld
 ```
 
-Or allow RustFS port 9000:
+Or allow the RustFS ports — 9000 (S3 API) and 9001 (Console):
 
 ```bash
 firewall-cmd --zone=public --add-port=9000/tcp --permanent
+firewall-cmd --zone=public --add-port=9001/tcp --permanent
 firewall-cmd --reload
 ```
 
@@ -263,7 +264,8 @@ RestartSec=10s
 OOMScoreAdjust=-1000
 SendSIGKILL=no
 
-TimeoutStartSec=30s
+# RustFS reports READY only after storage and peer checks pass; allow up to 120s.
+TimeoutStartSec=120s
 TimeoutStopSec=30s
 
 NoNewPrivileges=true

--- a/content/installation/macos/index.md
+++ b/content/installation/macos/index.md
@@ -1,16 +1,17 @@
 ---
-title: "Installing RustFS on MacOS"
-description: "This article mainly explains the quick startup methods for RustFS on MacOS"
+title: "Installing RustFS on macOS"
+description: "Quick ways to start RustFS on macOS, using the graphical one-click startup package."
 ---
 
-On MacOS, you can use three methods for installation:
+On macOS, you can use three methods for installation:
+
 1. Docker
 2. Graphical one-click startup package
 3. Binary package
 
 > This article mainly explains how to use the RustFS **graphical one-click startup package** to quickly launch RustFS.
 
-### 1. Preparation
+## 1. Preparation
 
 :::note
 
@@ -18,40 +19,41 @@ On MacOS, you can use three methods for installation:
 
 :::
 
-1. For detailed introduction about startup modes, please refer to [Startup Modes](../linux/index.md#mode);
-
+1. For detailed introduction about startup modes, please refer to [Installation Modes](../linux/quick-start.md#mode)
 2. Download the installation package, modify permissions, and start.
 
-### 2. Download
+## 2. Download
 
 Go to the official website download page and download the latest RustFS installation package.
 
-### 3. Modify Permissions
+## 3. Modify Permissions
 
-Please confirm that this program has relevant execution permissions in the MacOS operating system.
+Please confirm that this program has relevant execution permissions in the macOS operating system.
 
-### 4. Start the Service
+## 4. Start the Service
 
-1. Double-click the startup icon;
-
-2. Click configure disk;
-
+1. Double-click the startup icon
+2. Click configure disk
 3. Click "Start Service", and RustFS service starts successfully.
 
 ![macos startup](./images/macos-setup.jpg)
 
-### 5. Modify Configuration
+## 5. Modify Configuration
 
 Click the modify button (gear-shaped button) in the upper right corner to modify:
 
-1. Server default port;
-
-2. Default administrator username and password;
-
-3. Specified disk directory;
+1. Server default port
+2. Default administrator username and password
+3. Specified disk directory
 
 ![RustFS macOS configuration](./images/setting.jpg)
 
-### 6. Access Console
+## 6. Access Console
 
 After successful startup, visit `http://127.0.0.1:7001` to access the console.
+
+:::note
+
+Port `7001` applies to the macOS desktop launcher. If you run the standalone `rustfs` server binary instead, the console listens on port `9001` by default.
+
+:::

--- a/content/installation/windows/index.md
+++ b/content/installation/windows/index.md
@@ -11,7 +11,7 @@ Windows startup **mode** only supports single-node single-disk mode, more suitab
 
 :::
 
-1. For detailed introduction about Windows startup modes, please refer to [Startup Modes](../linux/index.md#mode);
+1. For detailed introduction about startup modes, please refer to [Installation Modes](../linux/quick-start.md#mode);
 
 2. Download the installation package, modify permissions, and start.
 
@@ -48,3 +48,9 @@ Click the modify button (gear-shaped button) in the upper right corner to modify
 ## 5. Access Console
 
 After successful startup, visit `http://127.0.0.1:7001` to access the console.
+
+:::note
+
+Port `7001` applies to the Windows desktop launcher. If you run the standalone `rustfs` server binary instead, the console listens on port `9001` by default.
+
+:::

--- a/content/integration/nginx.md
+++ b/content/integration/nginx.md
@@ -154,20 +154,28 @@ upstream rustfs-console {
 
 
 ## Dedicated DNS Mode
-Create or configure a dedicated DNS name for the RustFS service.
+Create or configure dedicated DNS names for the RustFS service — one hostname for the S3 API and one for the Console.
 
-Proxy requests for the RustFS server's S3 API to the /api/ path of this domain. Proxy requests for the RustFS Console Web GUI to the root path (/).
-For example, given the hostname www.rustfs.dev:
-Endpoint: `www.rustfs.dev/api/`
-Console: `www.rustfs.dev`
+:::warning[Do not proxy the S3 API under a path prefix]
 
+S3 clients sign the request path (AWS Signature V4). If you expose the API under a prefix such as `/api/`, RustFS receives paths like `/api/<bucket>/...`, interprets `api` as a bucket name, and signature validation fails. Always serve the S3 API from the root of its own hostname.
+
+:::
+
+For example:
+S3 endpoint: `s3.rustfs.dev`
+Console: `console.rustfs.dev`
 
 ~~~nginx title="/etc/nginx/conf.d/rustfs.conf (dedicated DNS)"
+# S3 API
 server {
-   listen       443;
-   listen  [::]:443;
+   listen       443 ssl;
+   listen  [::]:443 ssl;
    http2 on;
-   server_name  www.rustfs.dev;
+   server_name  s3.rustfs.dev;
+
+   ssl_certificate     /etc/nginx/certs/rustfs.dev.pem;
+   ssl_certificate_key /etc/nginx/certs/rustfs.dev.key;
 
    # Allow special characters in headers
    ignore_invalid_headers off;
@@ -178,9 +186,7 @@ server {
    proxy_buffering off;
    proxy_request_buffering off;
 
-# S3 API
-
-   location /api {
+   location / {
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -192,13 +198,24 @@ server {
       proxy_set_header Connection "";
       chunked_transfer_encoding off;
 
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
-
       proxy_pass http://127.0.0.1:9000;
    }
+}
 
 # Console
+server {
+   listen       443 ssl;
+   listen  [::]:443 ssl;
+   http2 on;
+   server_name  console.rustfs.dev;
+
+   ssl_certificate     /etc/nginx/certs/rustfs.dev.pem;
+   ssl_certificate_key /etc/nginx/certs/rustfs.dev.key;
+
+   ignore_invalid_headers off;
+   client_max_body_size 0;
+   proxy_buffering off;
+   proxy_request_buffering off;
 
    location / {
       proxy_set_header Host $http_host;
@@ -214,7 +231,7 @@ server {
 
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
-      proxy_pass http://127.0.0.1:9001; 
+      proxy_pass http://127.0.0.1:9001;
    }
 }
 ~~~

--- a/content/integration/tls-configured.md
+++ b/content/integration/tls-configured.md
@@ -34,7 +34,7 @@ Configure TLS for secure access. Set the `RUSTFS_TLS_PATH` environment variable.
     systemctl restart rustfs
     ```
 
-Access via `https://rustfs.example.com:9001`.
+TLS now applies to both listeners: the S3 API at `https://rustfs.example.com:9000` and the Console at `https://rustfs.example.com:9001`.
 
 ### Docker
 
@@ -44,7 +44,7 @@ Access via `https://rustfs.example.com:9001`.
         docker pull rustfs/rustfs:latest
         docker run -d \
         --name rustfs \
-        -e RUSTFS_TLS_PATH="/opt/tls/"
+        -e RUSTFS_TLS_PATH="/opt/tls/" \
         -v /opt/tls:/opt/tls \
         -p 9000:9000 \
         -p 9001:9001 \
@@ -52,6 +52,6 @@ Access via `https://rustfs.example.com:9001`.
         rustfs/rustfs:latest
     ```
 
-2. Restart the RustFS instance container, then access the instance through `https://rustfs.example.com:9001`.
+2. Restart the RustFS instance container, then access the S3 API at `https://rustfs.example.com:9000` and the Console at `https://rustfs.example.com:9001`.
 
 **Note**: Since the RustFS instance container runs as `rustfs` user by default, you need to ensure that the certificate files (`rustfs_key.pem` and `rustfs_cert.pem`) belong to the `rustfs` user, otherwise the RustFS instance will fail to read the certificate files due to permission issues, causing TLS configuration to fail.

--- a/content/integration/virtual.md
+++ b/content/integration/virtual.md
@@ -41,18 +41,18 @@ http://test.rustfs.yourdomain.com/
 
 ### Port in Domain (Optional)
 
-If your domain is accessed **with an explicit port**, include the port number in `RUSTFS_SERVER_DOMAINS`.
+Virtual-host routing applies to the S3 API listener (port 9000 by default); RustFS automatically matches `Host` headers that carry the S3 listener's own port. Only when clients reach RustFS through a **different** port (for example via a proxy) do you need to include that port in `RUSTFS_SERVER_DOMAINS`.
 
-Example (`rustfs.yourdomain.com:9001`):
+Example (`rustfs.yourdomain.com:8000`):
 
 ```ini
-RUSTFS_SERVER_DOMAINS = "rustfs.yourdomain.com:9001"
+RUSTFS_SERVER_DOMAINS = "rustfs.yourdomain.com:8000"
 ```
 
 This ensures that requests like:
 
 ```
-http://test.rustfs.yourdomain.com:9001/
+http://my-bucket.rustfs.yourdomain.com:8000/
 ```
 
 can be correctly resolved in Virtual Host Style mode.

--- a/content/management/bucket/creation.md
+++ b/content/management/bucket/creation.md
@@ -42,13 +42,12 @@ Create a bucket via API:
 PUT /{bucketName} HTTP/1.1
 ```
 
-Request example:
+S3 requests must be signed with AWS Signature V4, so use an S3 client rather than hand-crafting headers. With the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) configured for your access keys:
 
 ```bash
-curl --location --request PUT 'http://12.34.56.78:9000/bucket-creation-by-api' \
---header 'X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' \
---header 'X-Amz-Date: 20250801T023519Z' \
---header 'Authorization: AWS4-HMAC-SHA256 Credential=H4xcBZKQfvJjEnk3zp1N/20250801/cn-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=c2fb2ba5199a30ebcfa9976d0f35000ba274da3701327957e84ea0f3920288f2'
+aws s3api create-bucket \
+  --bucket bucket-creation-by-api \
+  --endpoint-url http://localhost:9000
 ```
 
 Verify the bucket creation in the RustFS Console.

--- a/content/management/bucket/deletion.md
+++ b/content/management/bucket/deletion.md
@@ -40,13 +40,12 @@ Delete a bucket via API:
 DELETE /{bucketName} HTTP/1.1
 ```
 
-Request example:
+S3 requests must be signed with AWS Signature V4, so use an S3 client rather than hand-crafting headers. With the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) configured for your access keys:
 
 ```bash
-curl --location --request DELETE 'http://12.34.56.78:9000/bucket-creation-by-api' \
---header 'X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' \
---header 'X-Amz-Date: 20250801T024406Z' \
---header 'Authorization: AWS4-HMAC-SHA256 Credential=H4xcBZKQfvJjEnk3zp1N/20250801/cn-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=d0f6addf09fffd7eef75191e9d3209bb7188e6b004e9707238fc60ad7033edae'
+aws s3api delete-bucket \
+  --bucket bucket-creation-by-api \
+  --endpoint-url http://localhost:9000
 ```
 
 Verify the bucket deletion in the RustFS Console.

--- a/content/management/object/creation.md
+++ b/content/management/object/creation.md
@@ -54,15 +54,14 @@ Upload a file via API:
 PUT /{bucketName}/{objectName} HTTP/1.1
 ```
 
-Request example:
+S3 requests must be signed with AWS Signature V4, so use an S3 client rather than hand-crafting headers. With the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) configured for your access keys:
 
 ```bash
-curl --location --request PUT 'http://12.34.56.78:9000/bucket-creation-by-api/password.txt' \
---header 'Content-Type: text/plain' \
---header 'X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' \
---header 'X-Amz-Date: 20250801T024840Z' \
---header 'Authorization: AWS4-HMAC-SHA256 Credential=H4xcBZKQfvJjEnk3zp1N/20250801/cn-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date, Signature=b7d8dc29ee34dfdf1f3e9e8e069892a8936f478586e7a2c90cf34f5b86d3a2dc' \
---data-binary '@/path/to/password.txt'
+aws s3api put-object \
+  --bucket bucket-creation-by-api \
+  --key hello.txt \
+  --body /path/to/hello.txt \
+  --endpoint-url http://localhost:9000
 ```
 
 Verify the upload in the RustFS Console.
@@ -80,12 +79,10 @@ DELETE /{bucketName}/{objectName} HTTP/1.1
 Request example:
 
 ```bash
-curl --location --request DELETE 'http://12.34.56.78:9000/bucket-creation-by-api/password.txt' \
---header 'Content-Type: text/plain' \
---header 'X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' \
---header 'X-Amz-Date: 20250801T030822Z' \
---header 'Authorization: AWS4-HMAC-SHA256 Credential=H4xcBZKQfvJjEnk3zp1N/20250801/cn-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date, Signature=1ee63bb0b699598602b2fdbd013e355a57bcb9991307a8ad41f6512e8afebf3a' \
---data-binary '@/Users/jhma/Desktop/password.txt'
+aws s3api delete-object \
+  --bucket bucket-creation-by-api \
+  --key hello.txt \
+  --endpoint-url http://localhost:9000
 ```
 
 You can confirm the file has been deleted on the RustFS UI.

--- a/content/management/object/deletion.md
+++ b/content/management/object/deletion.md
@@ -39,15 +39,13 @@ Delete a file via API:
 DELETE /{bucketName}/{objectName} HTTP/1.1
 ```
 
-Request example:
+S3 requests must be signed with AWS Signature V4, so use an S3 client rather than hand-crafting headers. With the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) configured for your access keys:
 
 ```bash
-curl --location --request DELETE 'http://12.34.56.78:9000/bucket-creation-by-api/password.txt' \
---header 'Content-Type: text/plain' \
---header 'X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' \
---header 'X-Amz-Date: 20250801T030822Z' \
---header 'Authorization: AWS4-HMAC-SHA256 Credential=H4xcBZKQfvJjEnk3zp1N/20250801/cn-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date, Signature=1ee63bb0b699598602b2fdbd013e355a57bcb9991307a8ad41f6512e8afebf3a' \
---data-binary '@/Users/jhma/Desktop/password.txt'
+aws s3api delete-object \
+  --bucket bucket-creation-by-api \
+  --key hello.txt \
+  --endpoint-url http://localhost:9000
 ```
 
 Verify the deletion in the RustFS Console.

--- a/content/troubleshooting/driver.md
+++ b/content/troubleshooting/driver.md
@@ -3,8 +3,6 @@ title: "Hard Drive Failures"
 description: "RustFS ensures read/write access can still be provided when some disks fail through mechanisms similar to erasure coding, and automatically heals data after replacing disks."
 ---
 
-# RustFS Disk Failure Troubleshooting Guide
-
 RustFS ensures read/write access can still be provided when some disks fail through mechanisms similar to erasure coding, and automatically heals data after replacing disks.
 
 ## Table of Contents
@@ -45,28 +43,28 @@ systemctl stop rustfs
 After physically replacing the failed disk, you need to partition and format the new disk, and apply the same label as the original disk.
 
 ```bash
-# Format as ext4 and apply label DISK1 (must correspond to original label)
-mkfs.ext4 /dev/sdb -L DISK1
+# Format as XFS and apply the same label as the original disk (RustFS requires XFS, like the other disks in the deployment)
+mkfs.xfs -L DISK1 /dev/sdb
 ```
 
 > **Requirements**
 >
 > * New disk capacity ≥ original disk capacity;
-> * File system type consistent with other disks;
+> * File system type consistent with other disks (XFS, per the [installation guide](../installation/linux/index.md));
 > * Recommend using labels (LABEL) or UUID for mounting to ensure disk order is not affected by system restarts.
 
 <a id="update-etcfstab-or-rustfs-configuration"></a>
 
 ### Update `/etc/fstab` or RustFS Configuration
 
-Confirm that the mount item labels or UUIDs in `/etc/fstab` point to the new disk. If using RustFS-specific configuration files (such as `config.yaml`), corresponding entries also need to be updated synchronously.
+Confirm that the mount item labels or UUIDs in `/etc/fstab` point to the new disk. The mount point must stay identical to the one listed in `RUSTFS_VOLUMES` (in `/etc/default/rustfs`), so the healed disk rejoins the cluster at the same path.
 
 ```bash
 # View current fstab
 cat /etc/fstab
 
 # Example fstab entry (no modification needed if labels are the same)
-LABEL=DISK1 /mnt/disk1 ext4 defaults,noatime 0 2
+LABEL=DISK1 /data/rustfs0 xfs defaults,noatime 0 2
 ```
 
 :::tip[Tips]
@@ -100,7 +98,7 @@ systemctl start rustfs
 Confirm all disks are mounted normally:
 
 ```bash
-df -h | grep /mnt/disk
+df -h | grep /data/rustfs
 ```
 
 :::note
@@ -113,28 +111,17 @@ If some mounts fail, please check if fstab entries are consistent with disk labe
 
 ### Trigger and Monitor Data Healing
 
-After RustFS detects the new disk, it will automatically or manually trigger the data healing process. The following example uses a hypothetical `rustfs-admin` tool:
-
-```bash
-# View current disk status
-rustfs-admin disk status
-
-# Manually trigger healing for the new disk
-rustfs-admin heal --disk /mnt/disk1
-
-# Real-time view of healing progress
-rustfs-admin heal status --follow
-```
-
-Additionally, you can confirm the system has recognized and started data recovery by viewing service logs:
+Once RustFS detects a freshly formatted disk at a known mount point, its background scanner heals the missing data onto it automatically — no manual command is required. Confirm that recovery has started and track its progress through the service logs:
 
 ```bash
 # For systemd-managed installations
 journalctl -u rustfs -f
 
-# Or view dedicated log files
-tail -f /var/log/rustfs/heal.log
+# Or view the log files under the directory set by RUSTFS_OBS_LOG_DIRECTORY
+tail -f /var/logs/rustfs/rustfs.log
 ```
+
+You can also open the RustFS Console and check the disk status of the affected node.
 
 :::note[Notes]
 

--- a/content/troubleshooting/healing.md
+++ b/content/troubleshooting/healing.md
@@ -1,13 +1,13 @@
 ---
 title: "Object Inspection and Auto-Recovery"
-description: "This article introduces RustFS's object self-healing function design and implementation in single-server multi-disk architecture, including the significance, principles, processes, configuration, and common troubleshooting of self-healing."
+description: "How RustFS object self-healing works: design principles, trigger paths, scrub and repair process, and usage notes."
 ---
 
 ## RustFS Architecture and Self-Healing Design
 
-### Single Server Multi-Disk Architecture
+### Erasure-Coded Storage Pools
 
-RustFS adopts a single-server multi-disk design, organizing multiple disks into a logical storage pool to provide object storage services. Each object is split into multiple data shards and redundant shards when written, and distributed across different disks to improve reliability and performance.
+RustFS organizes disks — on a single node or across nodes — into erasure-set storage pools. Each object is split into data shards and parity shards when written, and distributed across different disks (and nodes) to improve reliability and performance.
 
 ### Self-Healing Design Principles
 
@@ -33,37 +33,21 @@ When data scanning discovers inconsistencies, RustFS automatically calls the Rep
 
 ### Online Self-Healing During Reads
 
-Each time a client executes a `GET` or `HEAD` request, RustFS first checks all data shards of the corresponding object:
-1. If all data shards are intact, data is returned directly.
-2. If shards are lost or corrupted, the system calculates missing shards based on redundant shards, repairs them, then returns the complete object to the client.
-This mechanism is consistent with MinIO's read-time self-healing process, enabling transparent data repair without affecting client requests.
+When a client executes a `GET` or `HEAD` request, RustFS reads the data shards required to serve the object (a read quorum, not every shard):
+1. If enough shards are intact, data is returned directly.
+2. If shards are lost or corrupted, the system reconstructs the missing shards from parity shards, repairs them, then returns the complete object to the client.
+This enables transparent data repair without affecting client requests.
 
 ### Background Scanning Self-Healing
 
 RustFS has a built-in object scanner that traverses 1/1024 of objects in the storage pool using hash methods for integrity checks:
 - Object scanner runs lightweight verification periodically (configurable frequency);
 - If corruption is discovered, self-healing reconstruction process is immediately triggered.
-By default, deep bit rot checking is not performed to reduce resource overhead, but deep verification can be enabled as needed.
+Deep bit-rot verification runs on its own cycle (30 days by default) and can be tuned or disabled to trade thoroughness against resource overhead.
 
 ### Manual Trigger Self-Healing
 
-Administrators can execute full self-healing through command-line tools:
-
-```bash
-rc admin heal start --all
-```
-This operation scans the entire storage pool and performs complete verification and repair on all objects, consuming significant resources, so it should be used cautiously during low-peak periods.
-
-## Usage Examples
-
-```bash
-# View current self-healing status
-rc admin heal status
-# Start self-healing for specified bucket
-rc admin heal start --bucket photos
-# Stop ongoing self-healing tasks
-rc admin heal stop
-```
+Administrators can trigger a full heal through the RustFS Console or the admin API. A full heal scans the entire storage pool and performs complete verification and repair on all objects, consuming significant resources, so it should be used cautiously during low-peak periods.
 
 ## Summary
 

--- a/content/troubleshooting/node.md
+++ b/content/troubleshooting/node.md
@@ -39,7 +39,7 @@ In distributed RustFS clusters, erasure coding mechanisms are adopted to ensure 
 
 * **Configuration Verification**
 
- * Check whether the cluster node list (endpoints) in `config.yaml` includes the new node's hostname and port.
+ * Check that `RUSTFS_VOLUMES` in `/etc/default/rustfs` is byte-for-byte identical to the other nodes, and that it covers the replacement node's hostname and port.
  * Ensure all nodes have the same access keys and permission configurations to avoid new nodes being unable to join due to authentication failures.
 
 ## 4) Rejoin Cluster and Trigger Data Healing
@@ -47,26 +47,17 @@ In distributed RustFS clusters, erasure coding mechanisms are adopted to ensure 
 * **Start Service**
 
  ```bash
- systemctl start rustfs-server
+ systemctl start rustfs
  ```
 
-  Or use your custom startup script to start RustFS services, and view startup logs through `journalctl -u rustfs-server -f` to confirm the new node has detected other online nodes and started the data healing process.
+  Or use your custom startup script to start RustFS services, and view startup logs through `journalctl -u rustfs -f` to confirm the new node has detected other online nodes and started the data healing process.
 
-* **Manually Monitor Healing Status**
-  Use RustFS management tools (assuming the command is `rustfs-admin`) to view cluster health and healing progress:
+* **Monitor Healing Status**
+  Healing runs in the background once the node rejoins; no manual command is required. Watch its progress through the service logs on the replacement node, and check node and disk status in the RustFS Console:
 
  ```bash
- # View cluster node status
- rc cluster status
-
- # Trigger data healing for new node
- rc heal --node rustfs-node-2.example.net
-
- # Real-time tracking of healing progress
- rc heal status --follow
+ journalctl -u rustfs -f
  ```
-
-  Among them, the `heal` command is similar to RustFS's `rc admin heal`, ensuring all lost or inconsistent data shards are restored in the background.
 
 * **Community Experience Reference**
   Community testing shows that when nodes go offline and rejoin, RustFS will only perform healing operations on new nodes, not fully rebalance the cluster, thus avoiding unnecessary network and I/O peaks.

--- a/content/upgrade-scale/availability-and-resiliency.md
+++ b/content/upgrade-scale/availability-and-resiliency.md
@@ -126,9 +126,10 @@ chown -R rustfs-user:rustfs-user /data/rustfs*
 # Check rustfs version on existing node
 /usr/local/bin/rustfs --version
 
-# Download and install binary package (version must match existing cluster), e.g. for version 1.0.0-alpha.67:
-wget https://github.com/rustfs/rustfs/releases/download/1.0.0-alpha.67/rustfs-linux-x86_64-musl-latest.zip
-unzip rustfs-linux-x86_64-musl-latest.zip
+# Download the binary that matches the existing cluster version from
+# https://github.com/rustfs/rustfs/releases (asset name: rustfs-linux-x86_64-musl-v<version>.zip)
+wget https://github.com/rustfs/rustfs/releases/download/<version>/rustfs-linux-x86_64-musl-v<version>.zip
+unzip rustfs-linux-x86_64-musl-v<version>.zip
 chmod +x rustfs
 mv rustfs /usr/local/bin/
 ```
@@ -141,7 +142,7 @@ mv rustfs /usr/local/bin/
 cat <<EOF > /etc/default/rustfs
 RUSTFS_ACCESS_KEY=<Your RustFS admin username> # e.g. admin
 RUSTFS_SECRET_KEY=<Secure password of your RustFS admin> # e.g. output of: openssl rand -base64 24
-RUSTFS_VOLUMES="http://node-{1...4}:9000/data/rustfs{0...3} http://node-{5...8}:9000/data/rustfs{0...7}" # add new storage pool to the existing
+RUSTFS_VOLUMES="http://node{1...4}:9000/data/rustfs{0...3} http://node{5...8}:9000/data/rustfs{0...7}" # add new storage pool to the existing; must match the hostname pattern used by the existing nodes byte for byte
 RUSTFS_ADDRESS=":9000"
 RUSTFS_CONSOLE_ADDRESS=":9001"
 EOF
@@ -179,7 +180,9 @@ RestartSec=10s
 OOMScoreAdjust=-1000
 SendSIGKILL=no
 
-TimeoutStartSec=30s
+# RustFS reports READY only after storage, IAM, and peer checks pass; on a
+# full-cluster restart every node waits for its peers, so allow up to 120s.
+TimeoutStartSec=120s
 TimeoutStopSec=30s
 
 NoNewPrivileges=true
@@ -235,16 +238,13 @@ Open in the RustFS Console Performance menu, e.g. http://node1:9001/rustfs/conso
 
 ### 3.2 Data Balance Verification
 
-```bash
-# View data distribution ratio (should be close to each storage pool capacity ratio)
-watch -n 5 "rustfs-admin metrics | grep 'PoolUsagePercent'"
-```
+New objects are placed across pools according to available capacity. Check per-pool usage in the RustFS Console; it should trend toward each storage pool's capacity ratio. Existing data is not moved automatically — to spread it across the new pool, start a rebalance from the Console and expect it to run in the background for a while.
 
 ---
 
 ## Important Notes
 
-1. **Rolling Restart Prohibited**: Must restart all nodes simultaneously to avoid data inconsistency
+1. **Restart Scope**: Changing `RUSTFS_VOLUMES` (adding a storage pool) requires restarting all nodes so they agree on the new topology — restart them together during this operation. For routine binary upgrades or parameter changes, use a rolling restart (one node at a time) to avoid downtime.
 2. **Capacity Planning Recommendation**: Should plan next scaling when storage usage reaches 70%
 3. **Performance Tuning Recommendations**:
 
@@ -262,5 +262,5 @@ watch -n 5 "rustfs-admin metrics | grep 'PoolUsagePercent'"
 | Symptom | Check Point | Fix Command |
 |---------------------------|---------------------------------|-------------------------------|
 | New nodes cannot join cluster | Check port 9000 connectivity | `telnet node5 9000` |
-| Uneven data distribution | Check storage pool capacity configuration | `rustfs-admin rebalance start`|
+| Uneven data distribution | Check storage pool capacity configuration | Start a rebalance from the RustFS Console |
 | Console shows abnormal node status | Verify time synchronization status | `chronyc sources` |


### PR DESCRIPTION
## Summary (review workstream: P0 accuracy & safety — rustfs/backlog#1277)

Fixes the highest-risk factual errors and dangerous operational guidance found in the docs review (25 files + 1 test directory removed).

**Dangerous guidance (following it caused incidents):**
- Disk replacement: `mkfs.ext4` → `mkfs.xfs`; mount points aligned with the install layout (healing never triggered as written)
- Pool expansion: unified `RUSTFS_VOLUMES` hostname patterns across old/new nodes (as written, the whole cluster failed to start); "rolling restart prohibited" narrowed to "only pool changes need a full restart"; systemd `TimeoutStartSec` 30s → 120s (matches the upstream unit; 30s causes kill-restart loops on cold start)
- Nginx: added TLS directives to the 443 example; moved the S3 API off the `/api` path prefix (SigV4 breaks under a prefix); replaced the conflicting `Connection` header pairs with an `$http_upgrade` map so upstream keepalives survive while websocket upgrades still work — incorporates #76 by @jstangroome (the original PR targets the pre-migration `docs/` path)
- Firewall sections now open 9001 (Console) alongside 9000

**Fabricated content removed:** `rustfs-admin` / `rc` command families (self-described as "hypothetical"), nonexistent `config.toml`/`config.yaml`, nonexistent Operator/LogSearch/Elasticsearch/NSQ (real Pulsar target added); `developer/mcp.md` now warns that `crates/mcp` moved out of the main repo.

**Hard numbers corrected:** single PUT limit 500 GiB → **5 GiB** (the old number was MinIO's); EC read/write quorum formulas (read = N−parity, write = data shards); Blake3 → HighwayHash256; console port 9090 → 9001; desktop launcher port 7001 documented as distinct from the server default 9001; io_uring claims aligned with source (opt-in, off by default).

**Hygiene:** hand-signed SigV4 curl examples → `aws s3api`; private paths / `password.txt` / realistic-looking access keys / SSH clone URLs removed; leftover test page `content/deep/` deleted; broken `#mode` anchors fixed; "100% secure / 100% S3 compatible" claims removed.

Every correction is backed by a source citation (file:line) in the review reports (see the nav PR's `docs-review/`). Build: ✓ 355 pages.

---
Backed by the multi-role docs review (master issue rustfs/backlog#1277; six full reports ship in the nav PR under `docs-review/`). Technical facts verified against rustfs/rustfs@ea2e24ac.

## Rendered page previews (before / after)

<details><summary><code>/concepts/limit</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/concepts__limit.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/concepts__limit.png) |

</details>
<details><summary><code>/concepts/principle/erasure-coding</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/concepts__principle__erasure-coding.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/concepts__principle__erasure-coding.png) |

</details>
<details><summary><code>/developer/mcp</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/developer__mcp.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/developer__mcp.png) |

</details>
<details><summary><code>/installation/checklists/network-checklists</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/installation__checklists__network-checklists.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/installation__checklists__network-checklists.png) |

</details>
<details><summary><code>/installation/checklists/security-checklists</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/installation__checklists__security-checklists.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/installation__checklists__security-checklists.png) |

</details>
<details><summary><code>/installation/checklists/software-checklists</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/installation__checklists__software-checklists.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/installation__checklists__software-checklists.png) |

</details>
<details><summary><code>/installation/linux/multiple-node-multiple-disk</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/installation__linux__multiple-node-multiple-disk.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/installation__linux__multiple-node-multiple-disk.png) |

</details>
<details><summary><code>/installation/linux/single-node-multiple-disk</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/installation__linux__single-node-multiple-disk.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/installation__linux__single-node-multiple-disk.png) |

</details>
<details><summary><code>/installation/linux/single-node-single-disk</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/installation__linux__single-node-single-disk.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/installation__linux__single-node-single-disk.png) |

</details>
<details><summary><code>/integration/nginx</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/integration__nginx.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/integration__nginx.png) |

</details>
<details><summary><code>/integration/tls-configured</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/integration__tls-configured.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/integration__tls-configured.png) |

</details>
<details><summary><code>/integration/virtual</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/integration__virtual.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/integration__virtual.png) |

</details>
<details><summary><code>/management/bucket/creation</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/management__bucket__creation.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/management__bucket__creation.png) |

</details>
<details><summary><code>/management/bucket/deletion</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/management__bucket__deletion.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/management__bucket__deletion.png) |

</details>
<details><summary><code>/management/object/creation</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/management__object__creation.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/management__object__creation.png) |

</details>
<details><summary><code>/management/object/deletion</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/management__object__deletion.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/management__object__deletion.png) |

</details>
<details><summary><code>/troubleshooting/driver</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/troubleshooting__driver.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/troubleshooting__driver.png) |

</details>
<details><summary><code>/troubleshooting/healing</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/troubleshooting__healing.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/troubleshooting__healing.png) |

</details>
<details><summary><code>/troubleshooting/node</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/troubleshooting__node.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/troubleshooting__node.png) |

</details>
<details><summary><code>/upgrade-scale/availability-and-resiliency</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/upgrade-scale__availability-and-resiliency.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/upgrade-scale__availability-and-resiliency.png) |

</details>
<details><summary><code>/features/encryption</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/features__encryption.png)

</details>
<details><summary><code>/features/logging</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/features__logging.png)

</details>
<details><summary><code>/installation/linux</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/installation__linux.png)

</details>
<details><summary><code>/installation/macos</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/installation__macos.png)

</details>
<details><summary><code>/installation/windows</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/p0/installation__windows.png)

</details>
