### PR TITLE
docs: rewrite Quick Start end-to-end; restructure Docker guide with Tabs

### DIFF
--- a/content/installation/docker/index.mdx
+++ b/content/installation/docker/index.mdx
@@ -3,7 +3,7 @@ title: "Installing RustFS with Docker"
 description: "RustFS Docker deployment."
 ---
 
-RustFS is a high-performance, 100% S3-compatible open-source distributed object storage system. In single-node single-disk (SNSD) deployment mode, the backend uses zero erasure coding without additional data redundancy, suitable for local testing and small-scale scenarios.
+RustFS is a high-performance, S3-compatible open-source distributed object storage system. In single-node single-disk (SNSD) deployment mode, the backend uses zero erasure coding without additional data redundancy, suitable for local testing and small-scale scenarios.
 This article is based on RustFS official Linux binary packages, packaging RustFS and its runtime environment into containers through custom Dockerfile, and configuring data volumes and environment variables for one-click service startup.
 
 ---
@@ -16,18 +16,17 @@ This article is based on RustFS official Linux binary packages, packaging RustFS
  * Local path `/mnt/rustfs/data` (or custom path) for mounting object data
 2. **Network and Firewall**
 
- * Ensure host port 9000 is open to external access (or consistent with custom port)
-3. **Configuration File Preparation**
+ * Ensure host ports 9000 (S3 API) and 9001 (Console) are open to external access (or consistent with custom ports)
 
- * Define listening port, admin account, data path, etc. in host `/etc/rustfs/config.toml` (see Section 4 for details)
+3. **Directory Permissions**
 
-4. RustFS container run as non-root user `rustfs` with id `10001`, if you run docker with `-v` to mount host directory into docker container, please make sure the owner of host directory has been changed to `10001`, otherwise you will encounter permission denied error. You can run `chown -R 10001:10001 /path/to/host_directory` to grant the necessary permissions.
+ * The RustFS container runs as non-root user `rustfs` with id `10001`. If you run docker with `-v` to mount a host directory into the container, make sure the owner of the host directory is `10001`, otherwise you will encounter permission denied errors. Run `chown -R 10001:10001 /path/to/host_directory` to grant the necessary permissions.
 
 ---
 
-## 2. Quick Pull of RustFS Official Image
+## 2. Pull the RustFS Official Image
 
-Use official Ubuntu base image to quickly pull RustFS official image:
+Pull the official image (Alpine-based) from Docker Hub:
 
 ```bash
 docker pull rustfs/rustfs
@@ -60,52 +59,48 @@ Parameter descriptions:
 
 ---
 
-### Complete Parameter Configuration Example
+### Complete Configuration Example
 
-```bash {7,8,15,16}
+Configuration can be passed as environment variables (recommended) or as command-line flags — pick one style; when both are present, command-line flags win. The volume path (`/data`) always comes last.
+
+<Tabs items={["Environment variables", "Command-line flags"]}>
+  <Tab value="Environment variables" id="docker-env-config">
+
+```bash {7,8}
 # Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
 docker run -d \
-  --name rustfs_container \
+  --name rustfs \
   -p 9000:9000 \
   -p 9001:9001 \
   -v /mnt/rustfs/data:/data \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
+  -e RUSTFS_ADDRESS=:9000 \
   -e RUSTFS_CONSOLE_ENABLE=true \
-  -e RUSTFS_SERVER_DOMAINS=example.com \
   rustfs/rustfs:latest \
-  --address :9000 \
-  --console-enable \
-  --server-domains example.com \
-  --access-key "<your-access-key>" \
-  --secret-key "<your-secret-key>" \
   /data
 ```
 
-### Parameter Description and Corresponding Methods
+  </Tab>
+  <Tab value="Command-line flags" id="docker-cli-config">
 
-1. **Environment Variable Method** (Recommended):
-   ```bash
-   # Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
-   -e RUSTFS_ADDRESS=:9000 \
-   -e RUSTFS_SERVER_DOMAINS=example.com \
-   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
-   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
-   -e RUSTFS_CONSOLE_ENABLE=true \
-   ```
+```bash {8,9}
+# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
+docker run -d \
+  --name rustfs \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -v /mnt/rustfs/data:/data \
+  rustfs/rustfs:latest \
+  --access-key "<your-access-key>" \
+  --secret-key "<your-secret-key>" \
+  --address :9000 \
+  --console-enable \
+  /data
+```
 
-2. **Command Line Parameter Method**:
-   ```
-   # Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
-   --address :9000 \
-   --server-domains example.com \
-   --access-key "<your-access-key>" \
-   --secret-key "<your-secret-key>" \
-   --console-enable \
-   ```
-
-3. **Required Parameters**:
-    - `<VOLUMES>`: Specify at the end of command, such as `/data`
+  </Tab>
+</Tabs>
 
 ### Common Configuration Combinations
 
@@ -167,8 +162,8 @@ docker run -d \
 
 RustFS officially provides a Docker Compose installation method. The [`docker-compose.yml`](https://github.com/rustfs/rustfs/blob/main/docker-compose.yml) file includes multiple services, such as `grafana`, `prometheus`, `otel-collector`, and `jaeger`, mainly for observability. If you want to deploy these services together, clone the [RustFS code repository](https://github.com/rustfs/rustfs) locally,
 
-```
-git clone git@github.com:rustfs/rustfs.git
+```bash
+git clone https://github.com/rustfs/rustfs.git
 ```
 
 Running the command under root directory,
@@ -214,16 +209,9 @@ e7db806b2d6f   jaegertracing/all-in-one:latest                   "/go/bin/all-in
 1897830a2f1e   otel/opentelemetry-collector-contrib:latest       "/otelcol-contrib --…"   7 seconds ago   Up 5 seconds                      0.0.0.0:4317-4318->4317-4318/tcp, :::4317-4318->4317-4318/tcp, 0.0.0.0:8888-8889->8888-8889/tcp, :::8888-8889->8888-8889/tcp, 55679/tcp   otel-collector
 ```
 
-If you only want to install rustfs, do not want to deploy grafana,prometheus,etc, please comment below lines in `docker-compose.yml` file,
+If you only want to install RustFS without Grafana, Prometheus, and the other observability services, start just the `rustfs` service (the compose file marks the collector dependency as optional):
 
-```
-#depends_on:
-#  - otel-collector
-```
-
-Then, run the command,
-
-```
+```bash
 docker compose -f docker-compose.yml up -d rustfs
 ```
 
@@ -235,7 +223,7 @@ CONTAINER ID   IMAGE                                             COMMAND        
 e07121ecdd39   rustfs/rustfs:latest                              "/entrypoint.sh rust…"   2 seconds ago   Up 1 second (health: starting)   0.0.0.0:9000-9001->9000-9001/tcp, :::9000-9001->9000-9001/tcp   rustfs-server
 ```
 
-Whether you start only the `rustfs-server` or together with observability services, you can access the RustFS instance via `http://localhost:9000` using the access key and secret key you configured above (the `<your-access-key>` / `<your-secret-key>` placeholders). Generate a strong secret with, for example, `openssl rand -base64 24`, and never ship the placeholder values to production.
+Whether you start only the `rustfs-server` or together with observability services, the S3 API is served at `http://localhost:9000`, and the RustFS Console is at `http://localhost:9001` — open it in a browser and log in with the access key and secret key you configured above (the `<your-access-key>` / `<your-secret-key>` placeholders). Generate a strong secret with, for example, `openssl rand -base64 24`, and never ship the placeholder values to production.
 
 ## 4. Verification and Access
 

--- a/content/installation/linux/quick-start.md
+++ b/content/installation/linux/quick-start.md
@@ -1,41 +1,89 @@
 ---
-title: "Quick Start Guide for Linux"
-description: "Quick deployment and installation in Linux environment using RustFS one-click installation package"
+title: "Quick Start"
+description: "Install RustFS with the one-click script, log in to the Console, and store your first object — in about ten minutes."
 ---
 
-<a id="mode"></a>
+This guide takes you from an empty Linux server to a working RustFS instance: install, log in to the Console, create a bucket, and upload your first object. Production planning (multi-node layout, hardware sizing) is deliberately left for [the next step](#next-steps).
 
-## 1. Pre-Installation Reading
+**Prerequisites**
 
-This page contains complete documentation and instructions for all three installation modes of RustFS. Among them, the multi-machine multi-disk mode includes enterprise-grade performance, security, and scalability. It also provides architecture diagrams needed for production workloads. Please read before installation, our startup modes and checklists are as follows:
+- A Linux server (x86_64 or aarch64) with `systemd`, and root or sudo access
+- `unzip` installed, and outbound network access to download the package
+- Ports `9000` (S3 API) and `9001` (Console) reachable from your machine
 
-1. Choose one of the following installation modes:
+## 1. Install and start RustFS
 
-    - [Single Node Single Disk Mode (SNSD)](./single-node-single-disk.md)
-    - [Single Node Multiple Disk Mode (SNMD)](./single-node-multiple-disk.md)
-    - [Multiple Node Multiple Disk Mode (MNMD)](./multiple-node-multiple-disk.md)
-
-2. [Pre-Installation Check](../checklists/index.md), ensure your system meets the production requirements. For non-production environments, you can skip this step.
-
-## 2. Quick Installation
-
-The quick installation script sets up the **Single Node Single Disk (SNSD)** mode. The script is as follows:
+Run the official installation script:
 
 ```bash
 curl -O https://rustfs.com/install_rustfs.sh && bash install_rustfs.sh
 ```
 
-**Notes:**
-- Default installation port is `9000`.
-- Default installation path is `/data/rustfs0`. If you have independent disks, please mount them in advance.
-- Ensure `unzip` is installed to ensure RustFS zip installation package can be extracted normally.
+The script installs the binary to `/usr/local/bin/rustfs`, registers a `rustfs` systemd service, and starts it. By default it stores data in `/data/rustfs0` and listens on port `9000` (S3 API) and `9001` (Console); the data path and ports can be adjusted during installation. On success it prints a summary like:
 
-The quick installation script is available on GitHub at: https://github.com/rustfs/rustfs.com/blob/main/public/install_rustfs.sh
+```text
+RustFS has been installed and started successfully!
+Service port: 9000,  Console port: 9001,  Data directory: /data/rustfs0
 
-## 3. Other Important Notes
+[SECURITY WARNING] Please change the default value for RUSTFS_ACCESS_KEY/RUSTFS_SECRET_KEY immediately ...
+  Config file: /etc/default/rustfs
+```
 
-1. Verify firewall settings.
-2. Ensure NTP synchronization.
-3. Determine current disk capacity and planning.
-4. Confirm the operating system kernel version supports IO-Uring.
-5. Check SELinux settings.
+## 2. Set your credentials
+
+The generated config file ships placeholder credentials. Set your own access key and secret key, then restart the service:
+
+```ini title="/etc/default/rustfs" {1,2}
+RUSTFS_ACCESS_KEY=<your-access-key>
+RUSTFS_SECRET_KEY=<your-secret-key>   ; e.g. output of: openssl rand -base64 24
+```
+
+```bash
+sudo systemctl restart rustfs
+sudo systemctl status rustfs --no-pager   # should report: active (running)
+```
+
+:::warning[Do not keep default credentials]
+
+If `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` are not set, the server falls back to the built-in default `rustfsadmin` / `rustfsadmin` — acceptable for a throwaway local test, never for anything reachable by others.
+
+:::
+
+## 3. Log in to the Console
+
+Open `http://<server-ip>:9001` in your browser and sign in with the access key and secret key from step 2.
+
+![RustFS Console login](./images/console.jpg)
+
+## 4. Create a bucket and upload a file
+
+1. In the Console home page, select **Create Bucket**, name it (for example `my-bucket`), and confirm.
+2. Open the bucket and use the upload action to add any local file.
+3. Click the uploaded object to view its details — you have a working object store.
+
+Prefer the command line? The same two operations with the [MinIO Client (`mc`)](../../developer/mc.md):
+
+```bash
+mc alias set rustfs http://<server-ip>:9000 <your-access-key> <your-secret-key>
+mc mb rustfs/my-bucket
+mc cp ./hello.txt rustfs/my-bucket
+mc ls rustfs/my-bucket
+```
+
+```text
+Bucket created successfully `rustfs/my-bucket`.
+[2026-07-15 10:00:00 UTC]  12B hello.txt
+```
+
+<a id="mode"></a>
+
+## Next steps
+
+The quick install runs RustFS in **Single Node Single Disk (SNSD)** mode — zero redundancy, right for evaluation and development. Where to go from here:
+
+- **Plan a production deployment** — choose a topology, then follow its guide:
+  - [Single Node Single Disk (SNSD)](./single-node-single-disk.md) — dev and small workloads
+  - [Single Node Multiple Disk (SNMD)](./single-node-multiple-disk.md) — disk-level fault tolerance on one machine
+  - [Multiple Node Multiple Disk (MNMD)](./multiple-node-multiple-disk.md) — production-grade availability and scale, with the [pre-installation checklists](../checklists/index.md)
+- **Prefer containers?** — [Install with Docker](../docker/index.md)
+- **Connect your application** — [SDKs and examples](../../developer/sdk/index.md)


### PR DESCRIPTION
## Summary (review workstream: onboarding — rustfs/backlog#1270)

**Quick Start rewritten** as a true end-to-end path: install script → expected output → set credentials (`/etc/default/rustfs`, with a warning about the `rustfsadmin` fallback) → log in to the Console on `:9001` → create a bucket and upload → verify with `mc` → next steps (the SNSD/SNMD/MNMD topology reading moved here from the entry point). All ports, credential behavior, and script side-effects verified against the install script and upstream defaults. The `#mode` anchor is preserved for backward compatibility.

**Docker guide restructured** (renamed to `.mdx` to enable JSX; the URL is unchanged): the env-vars vs CLI-flags configuration — previously crammed into a single command — is now a `<Tabs>` choice with shareable anchors; removed the `config.toml` ghost reference; explained the 9001 Console mapping; updated the single-service compose start (upstream marks the collector dependency optional); Alpine base image wording; HTTPS clone URL.

Build: ✓ 359 pages; step circles, tabs, and line highlights verified in a local render.

---
Backed by the multi-role docs review (master issue rustfs/backlog#1277; six full reports ship in the nav PR under `docs-review/`). Technical facts verified against rustfs/rustfs@ea2e24ac.

## Rendered page previews (before / after)

<details><summary><code>/installation/linux/quick-start</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/installation__linux__quick-start.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/onboarding/installation__linux__quick-start.png) |

</details>
<details><summary><code>/installation/docker</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/onboarding/installation__docker.png)

</details>
