### PR TITLE
docs: make all six SDK guides copy-paste runnable

### DIFF
--- a/content/developer/sdk/go.md
+++ b/content/developer/sdk/go.md
@@ -1,126 +1,222 @@
 ---
 title: "Golang SDK Guide"
-description: "Use the Golang SDK to operate on RustFS instances, including creating and deleting buckets and objects."
+description: "Use the AWS SDK for Go v2 to operate on RustFS instances, including creating and deleting buckets and objects."
 ---
 
-RustFS is fully S3-compatible. You can use the standard AWS SDK for Go to interact with RustFS. Through the SDK, you can operate on RustFS, including creating and deleting buckets/objects, uploading and downloading files, etc.
+RustFS ships no first-party Go SDK — it is fully S3-compatible, so you use the official AWS SDK for Go v2 configured to point at your RustFS server. Through the SDK, you can operate on RustFS, including creating and deleting buckets/objects, uploading and downloading files, etc.
 
 ## Prerequisites
 
-- A working RustFS instance (refer to [Installation Guide](../../installation/index.md)).
-- Access keys (refer to [Access Key Management](../../administration/iam/access-token.md)).
+- Go 1.21 or later
+- A working RustFS instance (refer to [Installation Guide](../../installation/index.md)) — the S3 API listens on port `9000`, the Console on port `9001`
+- Access keys, set at install time via the `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` environment variables (refer to [Access Key Management](../../administration/iam/access-token.md))
+
+:::tip[Local test]
+
+If you did not set credentials at install time, the server defaults to `rustfsadmin` / `rustfsadmin` — fine for a throwaway local trial, never for anything reachable by others.
+
+:::
+
+Install the SDK modules:
+
+```bash
+go mod init rustfs-go-demo
+go get github.com/aws/aws-sdk-go-v2/aws
+go get github.com/aws/aws-sdk-go-v2/credentials
+go get github.com/aws/aws-sdk-go-v2/service/s3
+```
 
 ## Initializing the Client
 
-Configure `aws.Config` using environment variables and initialize the client:
+The following is a complete, runnable program. It reads its configuration from environment variables and initializes the client from an `aws.Config`:
 
-```go
-region := os.Getenv("RUSTFS_REGION")
-access_key_id := os.Getenv("RUSTFS_ACCESS_KEY_ID")
-secret_access_key := os.Getenv("RUSTFS_SECRET_ACCESS_KEY")
-endpoint := os.Getenv("RUSTFS_ENDPOINT_URL")
-// usePathStyle := strings.ToLower(os.Getenv("AWS_S3_USE_PATH_STYLE")) == "true"
+```go title="main.go"
+package main
 
-if access_key_id == "" || secret_access_key == "" || region == "" || endpoint == "" {
-    log.Fatal("missing the env: RUSTFS_ACCESS_KEY_ID / RUSTFS_SECRET_ACCESS_KEY / RUSTFS_REGION / RUSTFS_ENDPOINT_URL")
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func main() {
+	region := os.Getenv("RUSTFS_REGION")
+	accessKeyID := os.Getenv("RUSTFS_ACCESS_KEY_ID")
+	secretAccessKey := os.Getenv("RUSTFS_SECRET_ACCESS_KEY")
+	endpoint := os.Getenv("RUSTFS_ENDPOINT_URL")
+
+	if accessKeyID == "" || secretAccessKey == "" || region == "" || endpoint == "" {
+		log.Fatal("missing the env: RUSTFS_ACCESS_KEY_ID / RUSTFS_SECRET_ACCESS_KEY / RUSTFS_REGION / RUSTFS_ENDPOINT_URL")
+	}
+
+	// build aws.Config
+	cfg := aws.Config{
+		Region:      region,
+		Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, "")),
+	}
+
+	// build S3 client
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(endpoint)
+		// RustFS uses path-style URLs by default; virtual-host style requires RUSTFS_SERVER_DOMAINS
+		o.UsePathStyle = true
+	})
+
+	ctx := context.Background()
+
+	resp, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+	if err != nil {
+		log.Fatalf("list buckets failed: %v", err)
+	}
+
+	fmt.Println("Buckets:")
+	for _, b := range resp.Buckets {
+		fmt.Println(" -", *b.Name)
+	}
 }
-
-// build aws.Config
-cfg := aws.Config{
-    Region: region,
-    Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(access_key_id, secret_access_key, "")),
-}
-
-// build S3 client
-client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-    o.BaseEndpoint = aws.String(endpoint)
-    o.UsePathStyle = true
-})
 ```
 
-You can now perform bucket and object operations.
+:::note
+
+These environment variable names (`RUSTFS_ENDPOINT_URL`, `RUSTFS_REGION`, `RUSTFS_ACCESS_KEY_ID`, `RUSTFS_SECRET_ACCESS_KEY`) are just this example's client-side conventions — they are read by your Go program, not by RustFS. They are distinct from the server-side `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` variables used when installing RustFS.
+
+:::
+
+Run it (replace `localhost` with your server's IP address if RustFS runs on another machine):
+
+```bash
+export RUSTFS_ENDPOINT_URL="http://localhost:9000"
+export RUSTFS_REGION="us-east-1"
+export RUSTFS_ACCESS_KEY_ID="<your-access-key>"
+export RUSTFS_SECRET_ACCESS_KEY="<your-secret-key>"
+go run main.go
+```
+
+```text
+Buckets:
+ - my-bucket
+```
+
+You can now perform bucket and object operations. The snippets below run inside the `main` function above, reusing `client` and `ctx`.
 
 ## Create Bucket
 
-```
+```go
 _, err = client.CreateBucket(ctx, &s3.CreateBucketInput{
-    Bucket: aws.String("go-sdk-rustfs"),
+	Bucket: aws.String("my-bucket"),
 })
 if err != nil {
-    log.Fatalf("create bucket failed: %v", err)
+	log.Fatalf("create bucket failed: %v", err)
 }
+fmt.Println("bucket created")
+```
+
+```text
+bucket created
 ```
 
 ## List Buckets
 
-```
+```go
 resp, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
 if err != nil {
-    log.Fatalf("list buckets failed: %v", err)
+	log.Fatalf("list buckets failed: %v", err)
 }
 
 fmt.Println("Buckets:")
 for _, b := range resp.Buckets {
-    fmt.Println(" -", *b.Name)
+	fmt.Println(" -", *b.Name)
 }
+```
+
+```text
+Buckets:
+ - my-bucket
 ```
 
 ## Delete Bucket
 
-```
+```go
 _, err = client.DeleteBucket(ctx, &s3.DeleteBucketInput{
-    Bucket: aws.String("go-sdk-rustfs"),
+	Bucket: aws.String("my-bucket"),
 })
 if err != nil {
-    log.Fatalf("delete bucket failed: %v", err)
+	log.Fatalf("delete bucket failed: %v", err)
 }
+fmt.Println("bucket deleted")
+```
+
+```text
+bucket deleted
 ```
 
 ## List Objects
 
-```
+```go
 resp, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-    Bucket: aws.String("bucket-target"),
+	Bucket: aws.String("my-bucket"),
 })
 if err != nil {
-    log.Fatalf("list object failed: %v", err)
+	log.Fatalf("list object failed: %v", err)
 }
 for _, obj := range resp.Contents {
-    fmt.Println(" -", *obj.Key)
+	fmt.Println(" -", *obj.Key)
 }
+```
+
+```text
+ - hello.txt
 ```
 
 ## Upload Object
 
-```
+Uploading a string body (add `"strings"` to your imports):
+
+```go
 _, err = client.PutObject(ctx, &s3.PutObjectInput{
-    Bucket: aws.String("bucket-target"),
-    Key:    aws.String("test.txt"),
-    Body:   strings.NewReader("hello rustfs"),
+	Bucket: aws.String("my-bucket"),
+	Key:    aws.String("hello.txt"),
+	Body:   strings.NewReader("hello rustfs"),
 })
 if err != nil {
-    log.Fatalf("upload object failed: %v", err)
+	log.Fatalf("upload object failed: %v", err)
 }
+fmt.Println("object uploaded")
+```
+
+```text
+object uploaded
 ```
 
 ## Download Object
 
-```
+Reading the object body (add `"io"` to your imports):
+
+```go
 resp, err := client.GetObject(ctx, &s3.GetObjectInput{
-    Bucket: aws.String("bucket-target"),
-    Key:    aws.String("1.txt"),
+	Bucket: aws.String("my-bucket"),
+	Key:    aws.String("hello.txt"),
 })
 if err != nil {
-    log.Fatalf("download object fail: %v", err)
+	log.Fatalf("download object fail: %v", err)
 }
 defer resp.Body.Close()
 
 // read object content
 data, err := io.ReadAll(resp.Body)
 if err != nil {
-    log.Fatalf("read object content fail: %v", err)
+	log.Fatalf("read object content fail: %v", err)
 }
 fmt.Println("content is :", string(data))
 ```
 
-For other usage, you can explore on your own. It's even simpler with the help of an llm!
+```text
+content is : hello rustfs
+```
+
+For other operations (presigned URLs, multipart uploads, and more), see the [AWS SDK for Go v2 documentation](https://aws.github.io/aws-sdk-go-v2/docs/) — every S3-compatible call works against RustFS the same way.

--- a/content/developer/sdk/java.md
+++ b/content/developer/sdk/java.md
@@ -1,38 +1,48 @@
 ---
 title: "Java SDK Guide"
-description: "Guide to using the Java SDK with RustFS."
+description: "Use the official AWS SDK for Java v2 with RustFS."
 ---
 
-RustFS is S3-compatible. This guide demonstrates how to use the AWS SDK for Java v2 with RustFS.
+RustFS ships no first-party Java SDK — it is S3-compatible, so you use the official AWS SDK for Java v2 configured to point at your RustFS server.
 
-## 1. Setup
+## 1. Prerequisites
+
+* Java 8 or later and Maven (or Gradle)
+* A running RustFS instance (see the [Installation Guide](../../installation/index.md)) — the S3 API listens on port `9000`, the Console on port `9001`
+* Access keys, set at install time via the `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` environment variables (see [Access Key Management](../../administration/iam/access-token.md))
+
+:::tip[Local test]
+
+If you did not set credentials at install time, the server defaults to `rustfsadmin` / `rustfsadmin` — fine for a throwaway local trial, never for anything reachable by others.
+
+:::
 
 ### 1.1 Maven Project Setup
 
 Create a new Maven project:
 
-```
+```text
 rustfs-java-s3-demo/
 ├── pom.xml
 └── src/
- └── main/
- └── java/
- └── com/
- └── example/
- └── RustfsS3Example.java
+    └── main/
+        └── java/
+            └── com/
+                └── example/
+                    └── RustfsS3Example.java
 ```
 
 ### 1.2 Add Dependencies
 
 Add AWS SDK dependencies in `pom.xml`:
 
-```xml
+```xml title="pom.xml"
 <dependencies>
- <dependency>
- <groupId>software.amazon.awssdk</groupId>
- <artifactId>s3</artifactId>
- <version>2.25.27</version>
- </dependency>
+  <dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>s3</artifactId>
+    <version>2.25.27</version>
+  </dependency>
 </dependencies>
 ```
 
@@ -42,9 +52,11 @@ Add AWS SDK dependencies in `pom.xml`:
 
 ## 2. Connecting to RustFS
 
-### 2.1 Initialize the Client
+### 2.1 Complete Example
 
-```java
+The following class compiles and runs as-is. Replace `localhost` with your server's IP address if RustFS runs on another machine, and fill in your own access keys:
+
+```java title="RustfsS3Example.java"
 package com.example;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -58,55 +70,65 @@ import java.nio.file.Paths;
 
 public class RustfsS3Example {
 
- public static void main(String[] args) {
- // 1. Initialize S3 client
- S3Client s3 = S3Client.builder()
- .endpointOverride(URI.create("http://192.168.1.100:9000")) // RustFS address
- .region(Region.US_EAST_1) // RustFS does not validate regions
- .credentialsProvider(
- StaticCredentialsProvider.create(
- // Use a unique access key and a strong secret (e.g. openssl rand -base64 24)
- AwsBasicCredentials.create("<your-access-key>", "<your-secret-key>")
- )
- )
- .forcePathStyle(true) // Required for RustFS compatibility
- .build();
+    public static void main(String[] args) {
+        // 1. Initialize S3 client
+        S3Client s3 = S3Client.builder()
+            .endpointOverride(URI.create("http://localhost:9000")) // RustFS S3 API address
+            .region(Region.US_EAST_1) // RustFS default region
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create("<your-access-key>", "<your-secret-key>")
+                )
+            )
+            // RustFS uses path-style URLs by default; virtual-host style requires RUSTFS_SERVER_DOMAINS
+            .forcePathStyle(true)
+            .build();
 
- // 2. Create Bucket
- String bucket = "my-bucket";
- try {
- s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
- System.out.println("Bucket created: " + bucket);
- } catch (BucketAlreadyExistsException | BucketAlreadyOwnedByYouException e) {
- System.out.println("Bucket already exists.");
- }
+        // 2. Create bucket
+        String bucket = "my-bucket";
+        try {
+            s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+            System.out.println("Bucket created: " + bucket);
+        } catch (BucketAlreadyExistsException | BucketAlreadyOwnedByYouException e) {
+            System.out.println("Bucket already exists.");
+        }
 
- // 3. Upload file
- s3.putObject(
- PutObjectRequest.builder().bucket(bucket).key("hello.txt").build(),
- Paths.get("hello.txt")
- );
- System.out.println("Uploaded hello.txt");
+        // 3. Upload file
+        s3.putObject(
+            PutObjectRequest.builder().bucket(bucket).key("hello.txt").build(),
+            Paths.get("/path/to/hello.txt")
+        );
+        System.out.println("Uploaded hello.txt");
 
- // 4. Download file
- s3.getObject(
- GetObjectRequest.builder().bucket(bucket).key("hello.txt").build(),
- Paths.get("downloaded-hello.txt")
- );
- System.out.println("Downloaded hello.txt");
+        // 4. Download file
+        s3.getObject(
+            GetObjectRequest.builder().bucket(bucket).key("hello.txt").build(),
+            Paths.get("downloaded-hello.txt")
+        );
+        System.out.println("Downloaded hello.txt");
 
- // 5. List objects
- ListObjectsV2Response listResponse = s3.listObjectsV2(ListObjectsV2Request.builder().bucket(bucket).build());
- listResponse.contents().forEach(obj -> System.out.println("Found object: " + obj.key()));
+        // 5. List objects
+        ListObjectsV2Response listResponse = s3.listObjectsV2(ListObjectsV2Request.builder().bucket(bucket).build());
+        listResponse.contents().forEach(obj -> System.out.println("Found object: " + obj.key()));
 
- // 6. Delete object
- s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key("hello.txt").build());
- System.out.println("Deleted hello.txt");
+        // 6. Delete object
+        s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key("hello.txt").build());
+        System.out.println("Deleted hello.txt");
 
- // 7. Delete bucket (optional)
- // s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
- }
+        // 7. Delete bucket (optional)
+        // s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
+    }
 }
+```
+
+Expected output:
+
+```text
+Bucket created: my-bucket
+Uploaded hello.txt
+Downloaded hello.txt
+Found object: hello.txt
+Deleted hello.txt
 ```
 
 ---
@@ -115,7 +137,7 @@ public class RustfsS3Example {
 
 | Issue | Cause | Solution |
 | -------------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `S3Exception: 301 Moved Permanently` | Path-style not enabled or region error | Set `.forcePathStyle(true)` and use any value for region |
+| `S3Exception: 301 Moved Permanently` | Path-style not enabled or region error | Set `.forcePathStyle(true)` and use region `us-east-1` |
 | `ConnectException: Connection refused` | RustFS not started or incorrect port | Check RustFS status and port |
 | `403 Forbidden` | AccessKey / SecretKey error | Check authentication configuration |
 | Upload fails with no response | SDK defaults to HTTPS, RustFS only supports HTTP (or needs certificates) | Use `http://` address and configure `endpointOverride` |
@@ -146,7 +168,7 @@ java -cp target/rustfs-java-s3-demo-1.0-SNAPSHOT.jar com.example.RustfsS3Example
 
 ---
 
-Good, below is the **RustFS AWS S3 Java SDK Advanced Features Example Supplement**, including:
+The following advanced examples cover:
 
 * Presigned URL generation and usage
 * Multipart Upload complete process
@@ -162,33 +184,49 @@ Good, below is the **RustFS AWS S3 Java SDK Advanced Features Example Supplement
 #### 5.1.1 Generate Download Link (GET)
 
 ```java
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.net.URI;
+import java.time.Duration;
 
 S3Presigner presigner = S3Presigner.builder()
- .endpointOverride(URI.create("http://192.168.1.100:9000"))
- .region(Region.US_EAST_1)
- .credentialsProvider(
- StaticCredentialsProvider.create(
- // Use a unique access key and a strong secret (e.g. openssl rand -base64 24)
- AwsBasicCredentials.create("<your-access-key>", "<your-secret-key>")
- )
- )
- .build();
+    .endpointOverride(URI.create("http://localhost:9000"))
+    .region(Region.US_EAST_1)
+    .credentialsProvider(
+        StaticCredentialsProvider.create(
+            AwsBasicCredentials.create("<your-access-key>", "<your-secret-key>")
+        )
+    )
+    // The presigner must also sign path-style URLs
+    .serviceConfiguration(
+        S3Configuration.builder().pathStyleAccessEnabled(true).build()
+    )
+    .build();
 
 GetObjectRequest getObjectRequest = GetObjectRequest.builder()
- .bucket("my-bucket")
- .key("hello.txt")
- .build();
+    .bucket("my-bucket")
+    .key("hello.txt")
+    .build();
 
 GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
- .getObjectRequest(getObjectRequest)
- .signatureDuration(Duration.ofMinutes(15)) // 15 minutes validity
- .build();
+    .getObjectRequest(getObjectRequest)
+    .signatureDuration(Duration.ofMinutes(15)) // 15 minutes validity
+    .build();
 
 PresignedGetObjectRequest presignedRequest = presigner.presignGetObject(presignRequest);
 
 System.out.println("Presigned URL: " + presignedRequest.url());
+```
+
+```text
+Presigned URL: http://localhost:9000/my-bucket/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&...
 ```
 
 > 🔗 Open the link in browser to access the object.
@@ -198,16 +236,20 @@ System.out.println("Presigned URL: " + presignedRequest.url());
 Similarly, you can also generate upload URLs:
 
 ```java
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
 PutObjectRequest putRequest = PutObjectRequest.builder()
- .bucket("my-bucket")
- .key("upload.txt")
- .build();
+    .bucket("my-bucket")
+    .key("upload.txt")
+    .build();
 
 PresignedPutObjectRequest presignedPut = presigner.presignPutObject(
- PutObjectPresignRequest.builder()
- .putObjectRequest(putRequest)
- .signatureDuration(Duration.ofMinutes(10))
- .build()
+    PutObjectPresignRequest.builder()
+        .putObjectRequest(putRequest)
+        .signatureDuration(Duration.ofMinutes(10))
+        .build()
 );
 
 System.out.println("Upload URL: " + presignedPut.url());
@@ -219,13 +261,23 @@ System.out.println("Upload URL: " + presignedPut.url());
 
 > Multipart Upload is the recommended way for large file uploads, enabling resume from breakpoint during network fluctuations.
 
+The examples below reuse the `s3` client from section 2 and need these additional imports:
+
+```java
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+```
+
 #### 5.2.1 Start Multipart Upload
 
 ```java
 CreateMultipartUploadRequest createRequest = CreateMultipartUploadRequest.builder()
- .bucket("my-bucket")
- .key("bigfile.zip")
- .build();
+    .bucket("my-bucket")
+    .key("bigfile.zip")
+    .build();
 
 CreateMultipartUploadResponse createResponse = s3.createMultipartUpload(createRequest);
 String uploadId = createResponse.uploadId();
@@ -236,21 +288,21 @@ String uploadId = createResponse.uploadId();
 ```java
 List<CompletedPart> completedParts = new ArrayList<>();
 for (int i = 1; i <= 3; i++) {
- String partPath = "part" + i + ".bin"; // Assume each part is a local file
- UploadPartRequest uploadPartRequest = UploadPartRequest.builder()
- .bucket("my-bucket")
- .key("bigfile.zip")
- .uploadId(uploadId)
- .partNumber(i)
- .build();
+    String partPath = "part" + i + ".bin"; // Assume each part is a local file
+    UploadPartRequest uploadPartRequest = UploadPartRequest.builder()
+        .bucket("my-bucket")
+        .key("bigfile.zip")
+        .uploadId(uploadId)
+        .partNumber(i)
+        .build();
 
- UploadPartResponse uploadPartResponse = s3.uploadPart(uploadPartRequest, Paths.get(partPath));
- completedParts.add(
- CompletedPart.builder()
- .partNumber(i)
- .eTag(uploadPartResponse.eTag())
- .build()
- );
+    UploadPartResponse uploadPartResponse = s3.uploadPart(uploadPartRequest, Paths.get(partPath));
+    completedParts.add(
+        CompletedPart.builder()
+            .partNumber(i)
+            .eTag(uploadPartResponse.eTag())
+            .build()
+    );
 }
 ```
 
@@ -258,30 +310,36 @@ for (int i = 1; i <= 3; i++) {
 
 ```java
 CompletedMultipartUpload completedUpload = CompletedMultipartUpload.builder()
- .parts(completedParts)
- .build();
+    .parts(completedParts)
+    .build();
 
 CompleteMultipartUploadRequest completeRequest = CompleteMultipartUploadRequest.builder()
- .bucket("my-bucket")
- .key("bigfile.zip")
- .uploadId(uploadId)
- .multipartUpload(completedUpload)
- .build();
+    .bucket("my-bucket")
+    .key("bigfile.zip")
+    .uploadId(uploadId)
+    .multipartUpload(completedUpload)
+    .build();
 
 s3.completeMultipartUpload(completeRequest);
 System.out.println("Multipart upload completed.");
+```
+
+```text
+Multipart upload completed.
 ```
 
 #### 5.2.4 Abort Upload on Exception (Optional)
 
 ```java
 AbortMultipartUploadRequest abortRequest = AbortMultipartUploadRequest.builder()
- .bucket("my-bucket")
- .key("bigfile.zip")
- .uploadId(uploadId)
- .build();
+    .bucket("my-bucket")
+    .key("bigfile.zip")
+    .uploadId(uploadId)
+    .build();
 
 s3.abortMultipartUpload(abortRequest);
 ```
 
 ---
+
+For other operations (object tagging, bucket policies, and more), see the [AWS SDK for Java v2 documentation](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/) — every S3-compatible call works against RustFS the same way.

--- a/content/developer/sdk/javascript.md
+++ b/content/developer/sdk/javascript.md
@@ -1,13 +1,23 @@
 ---
 title: "JavaScript SDK Guide"
-description: "Guide to using the JavaScript SDK with RustFS."
+description: "Use the official AWS SDK for JavaScript v3 with RustFS."
 ---
 
 ## I. Overview
 
-RustFS is S3-compatible and works with the official AWS SDK for JavaScript (v3). This guide will show you how to use JS to connect to RustFS and perform common object storage operations.
+RustFS ships no first-party JavaScript SDK — it is S3-compatible, so you use the official AWS SDK for JavaScript (v3) configured to point at your RustFS server. This guide shows how to connect to RustFS and perform common object storage operations.
 
 ## II. Prerequisites
+
+* Node.js 18 or later
+* A running RustFS instance (see the [Installation Guide](../../installation/index.md)) — the S3 API listens on port `9000`, the Console on port `9001`
+* Access keys, set at install time via the `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` environment variables (see [Access Key Management](../../administration/iam/access-token.md))
+
+:::tip[Local test]
+
+If you did not set credentials at install time, the server defaults to `rustfsadmin` / `rustfsadmin` — fine for a throwaway local trial, never for anything reachable by others.
+
+:::
 
 ### 2.1 SDK Installation
 
@@ -17,39 +27,43 @@ Install the required AWS SDK v3 modules with NPM:
 npm install @aws-sdk/client-s3 @aws-sdk/s3-request-presigner
 ```
 
-### 2.2 Example Configuration
-
-Assume the RustFS instance is deployed as follows:
-
-```
-Endpoint: http://192.168.1.100:9000
-Access Key: <your-access-key>
-Secret Key: <your-secret-key>
-```
+The examples below use ES modules (`import`). Set `"type": "module"` in your `package.json`, or save the files with the `.mjs` extension.
 
 ---
 
 ## III. Initializing the Client
 
-```js
-import { S3Client } from "@aws-sdk/client-s3";
-import { NodeHttpHandler } from "@smithy/node-http-handler";
+The following is a complete, runnable script. Replace `localhost` with your server's IP address if RustFS runs on another machine, and fill in your own access keys:
+
+```js title="main.mjs"
+import { S3Client, ListBucketsCommand } from "@aws-sdk/client-s3";
 
 const s3 = new S3Client({
- endpoint: "http://192.168.1.100:9000", // RustFS endpoint
- region: "us-east-1", // Any value is accepted
- credentials: {
- // Use a unique access key and a strong secret (e.g. openssl rand -base64 24)
- accessKeyId: "<your-access-key>",
- secretAccessKey: "<your-secret-key>",
- },
- forcePathStyle: true, // Must be enabled for RustFS compatibility
- requestHandler: new NodeHttpHandler({
- connectionTimeout: 3000,
- socketTimeout: 5000,
- }),
+  endpoint: "http://localhost:9000", // RustFS S3 API address
+  region: "us-east-1", // RustFS default region
+  credentials: {
+    accessKeyId: "<your-access-key>",
+    secretAccessKey: "<your-secret-key>",
+  },
+  // RustFS uses path-style URLs by default; virtual-host style requires RUSTFS_SERVER_DOMAINS
+  forcePathStyle: true,
 });
+
+const { Buckets } = await s3.send(new ListBucketsCommand({}));
+console.log(Buckets?.map((b) => b.Name) ?? []);
 ```
+
+Run it:
+
+```bash
+node main.mjs
+```
+
+```text
+[ 'my-bucket' ]
+```
+
+All snippets below reuse this `s3` client.
 
 ---
 
@@ -64,6 +78,10 @@ await s3.send(new CreateBucketCommand({ Bucket: "my-bucket" }));
 console.log("Bucket created");
 ```
 
+```text
+Bucket created
+```
+
 ---
 
 ### 4.2 Upload Object
@@ -72,17 +90,21 @@ console.log("Bucket created");
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { readFileSync } from "fs";
 
-const data = readFileSync("hello.txt");
+const data = readFileSync("/path/to/hello.txt");
 
 await s3.send(
- new PutObjectCommand({
- Bucket: "my-bucket",
- Key: "hello.txt",
- Body: data,
- })
+  new PutObjectCommand({
+    Bucket: "my-bucket",
+    Key: "hello.txt",
+    Body: data,
+  })
 );
 
 console.log("File uploaded");
+```
+
+```text
+File uploaded
 ```
 
 ---
@@ -94,19 +116,23 @@ import { GetObjectCommand } from "@aws-sdk/client-s3";
 import { writeFile } from "fs/promises";
 
 const response = await s3.send(
- new GetObjectCommand({ Bucket: "my-bucket", Key: "hello.txt" })
+  new GetObjectCommand({ Bucket: "my-bucket", Key: "hello.txt" })
 );
 
 const streamToBuffer = async (stream) => {
- const chunks = [];
- for await (const chunk of stream) chunks.push(chunk);
- return Buffer.concat(chunks);
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return Buffer.concat(chunks);
 };
 
 const buffer = await streamToBuffer(response.Body);
 await writeFile("downloaded.txt", buffer);
 
 console.log("File downloaded");
+```
+
+```text
+File downloaded
 ```
 
 ---
@@ -120,6 +146,10 @@ const res = await s3.send(new ListObjectsV2Command({ Bucket: "my-bucket" }));
 res.Contents?.forEach((obj) => console.log(`${obj.Key} (${obj.Size} bytes)`));
 ```
 
+```text
+hello.txt (12 bytes)
+```
+
 ---
 
 ### 4.5 Delete Object
@@ -129,6 +159,10 @@ import { DeleteObjectCommand } from "@aws-sdk/client-s3";
 
 await s3.send(new DeleteObjectCommand({ Bucket: "my-bucket", Key: "hello.txt" }));
 console.log("File deleted");
+```
+
+```text
+File deleted
 ```
 
 ---
@@ -146,23 +180,28 @@ import { GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 const url = await getSignedUrl(
- s3,
- new GetObjectCommand({ Bucket: "my-bucket", Key: "hello.txt" }),
- { expiresIn: 600 }
+  s3,
+  new GetObjectCommand({ Bucket: "my-bucket", Key: "hello.txt" }),
+  { expiresIn: 600 }
 );
 
 console.log("Presigned GET URL:", url);
+```
+
+```text
+Presigned GET URL: http://localhost:9000/my-bucket/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&...
 ```
 
 #### Upload (PUT)
 
 ```js
 import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 const url = await getSignedUrl(
- s3,
- new PutObjectCommand({ Bucket: "my-bucket", Key: "upload.txt" }),
- { expiresIn: 600 }
+  s3,
+  new PutObjectCommand({ Bucket: "my-bucket", Key: "upload.txt" }),
+  { expiresIn: 600 }
 );
 
 console.log("Presigned PUT URL:", url);
@@ -174,12 +213,12 @@ console.log("Presigned PUT URL:", url);
 
 ```js
 import {
- CreateMultipartUploadCommand,
- UploadPartCommand,
- CompleteMultipartUploadCommand,
- AbortMultipartUploadCommand,
+  CreateMultipartUploadCommand,
+  UploadPartCommand,
+  CompleteMultipartUploadCommand,
+  AbortMultipartUploadCommand,
 } from "@aws-sdk/client-s3";
-import { createReadStream } from "fs";
+import { statSync, openSync, readSync, closeSync } from "fs";
 
 const bucket = "my-bucket";
 const key = "large-file.zip";
@@ -188,48 +227,50 @@ const partSize = 5 * 1024 * 1024; // 5 MB
 
 // 1. Create upload task
 const createRes = await s3.send(
- new CreateMultipartUploadCommand({ Bucket: bucket, Key: key })
+  new CreateMultipartUploadCommand({ Bucket: bucket, Key: key })
 );
 const uploadId = createRes.UploadId;
 
 // 2. Segmented upload
-import { statSync, openSync, readSync, closeSync } from "fs";
-
 const fileSize = statSync(filePath).size;
 const fd = openSync(filePath, "r");
 const parts = [];
 
 for (let partNumber = 1, offset = 0; offset < fileSize; partNumber++) {
- const buffer = Buffer.alloc(Math.min(partSize, fileSize - offset));
- readSync(fd, buffer, 0, buffer.length, offset);
+  const buffer = Buffer.alloc(Math.min(partSize, fileSize - offset));
+  readSync(fd, buffer, 0, buffer.length, offset);
 
- const uploadPartRes = await s3.send(
- new UploadPartCommand({
- Bucket: bucket,
- Key: key,
- UploadId: uploadId,
- PartNumber: partNumber,
- Body: buffer,
- })
- );
+  const uploadPartRes = await s3.send(
+    new UploadPartCommand({
+      Bucket: bucket,
+      Key: key,
+      UploadId: uploadId,
+      PartNumber: partNumber,
+      Body: buffer,
+    })
+  );
 
- parts.push({ ETag: uploadPartRes.ETag, PartNumber: partNumber });
- offset += partSize;
+  parts.push({ ETag: uploadPartRes.ETag, PartNumber: partNumber });
+  offset += partSize;
 }
 
 closeSync(fd);
 
 // 3. Complete upload
 await s3.send(
- new CompleteMultipartUploadCommand({
- Bucket: bucket,
- Key: key,
- UploadId: uploadId,
- MultipartUpload: { Parts: parts },
- })
+  new CompleteMultipartUploadCommand({
+    Bucket: bucket,
+    Key: key,
+    UploadId: uploadId,
+    MultipartUpload: { Parts: parts },
+  })
 );
 
 console.log("Multipart upload completed");
+```
+
+```text
+Multipart upload completed
 ```
 
 ---
@@ -255,19 +296,20 @@ Frontend (HTML+JS) upload example:
 ```html
 <input type="file" id="fileInput" />
 <script>
- document.getElementById("fileInput").addEventListener("change", async (e) => {
- const file = e.target.files[0];
- const url = await fetch("/api/presigned-put-url?key=" + file.name).then((r) =>
- r.text()
- );
+  document.getElementById("fileInput").addEventListener("change", async (e) => {
+    const file = e.target.files[0];
+    const url = await fetch("/api/presigned-put-url?key=" + file.name).then((r) =>
+      r.text()
+    );
 
- const res = await fetch(url, {
- method: "PUT",
- body: file,
- });
+    const res = await fetch(url, {
+      method: "PUT",
+      body: file,
+    });
 
- if (res.ok) alert("Uploaded!");
- });
+    if (res.ok) alert("Uploaded!");
+  });
 </script>
 ```
 
+For other operations (object tagging, bucket policies, and more), see the [AWS SDK for JavaScript v3 documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/) — every S3-compatible call works against RustFS the same way.

--- a/content/developer/sdk/python.md
+++ b/content/developer/sdk/python.md
@@ -1,11 +1,11 @@
 ---
 title: "Python SDK Guide"
-description: "Guide to using the Python SDK with RustFS."
+description: "Use the official AWS SDK for Python (Boto3) with RustFS."
 ---
 
 ## 1. Overview
 
-RustFS is S3-compatible and supports the [Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) SDK.
+RustFS ships no first-party SDKs — it is S3-compatible, so you use the official AWS SDK for Python, [Boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html), configured to point at your RustFS server.
 
 This guide covers:
 
@@ -17,19 +17,19 @@ This guide covers:
 
 ---
 
-## 2. Environment Preparation
+## 2. Prerequisites
 
-### 2.1 Example Configuration
+* Python 3.8 or later
+* A running RustFS instance (see the [Installation Guide](../../installation/index.md)) — the S3 API listens on port `9000`, the Console on port `9001`
+* Access keys, set at install time via the `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` environment variables (see [Access Key Management](../../administration/iam/access-token.md))
 
-Assume RustFS is deployed as follows:
+:::tip[Local test]
 
-```
-Endpoint: http://192.168.1.100:9000
-AccessKey: <your-access-key>
-SecretKey: <your-secret-key>
-```
+If you did not set credentials at install time, the server defaults to `rustfsadmin` / `rustfsadmin` — fine for a throwaway local trial, never for anything reachable by others.
 
-### 2.2 Install Boto3
+:::
+
+### 2.1 Install Boto3
 
 We recommend using a virtual environment:
 
@@ -45,24 +45,43 @@ pip install boto3
 
 ## 3. Connecting to RustFS
 
-```python
+The following is a complete, runnable script. Replace `localhost` with your server's IP address if RustFS runs on another machine, and fill in your own access keys:
+
+```python title="main.py"
 import boto3
 from botocore.client import Config
 
 s3 = boto3.client(
- 's3',
- endpoint_url='http://192.168.1.100:9000',
- # Use a unique access key and a strong secret (e.g. openssl rand -base64 24)
- aws_access_key_id='<your-access-key>',
- aws_secret_access_key='<your-secret-key>',
- config=Config(signature_version='s3v4'),
- region_name='us-east-1'
+    's3',
+    endpoint_url='http://localhost:9000',
+    aws_access_key_id='<your-access-key>',
+    aws_secret_access_key='<your-secret-key>',
+    region_name='us-east-1',
+    config=Config(
+        signature_version='s3v4',
+        s3={'addressing_style': 'path'},
+    ),
 )
+
+response = s3.list_buckets()
+for bucket in response['Buckets']:
+    print(bucket['Name'])
 ```
 
-> ✅ `endpoint_url`: Points to RustFS
-> ✅ `signature_version='s3v4'`: RustFS supports v4 signatures
-> ✅ `region_name`: RustFS does not validate regions; you can use any value.
+Run it:
+
+```bash
+python main.py
+```
+
+:::note[Client parameters explained]
+
+- `endpoint_url` — points to your RustFS S3 API (port `9000`, not the Console port `9001`)
+- `signature_version='s3v4'` — RustFS supports v4 signatures
+- `region_name='us-east-1'` — RustFS's default region
+- `addressing_style='path'` — RustFS uses path-style URLs by default; virtual-host style requires `RUSTFS_SERVER_DOMAINS`
+
+:::
 
 ---
 
@@ -74,10 +93,14 @@ s3 = boto3.client(
 bucket_name = 'my-bucket'
 
 try:
- s3.create_bucket(Bucket=bucket_name)
- print(f'Bucket {bucket_name} created.')
+    s3.create_bucket(Bucket=bucket_name)
+    print(f'Bucket {bucket_name} created.')
 except s3.exceptions.BucketAlreadyOwnedByYou:
- print(f'Bucket {bucket_name} already exists.')
+    print(f'Bucket {bucket_name} already exists.')
+```
+
+```text
+Bucket my-bucket created.
 ```
 
 ---
@@ -85,8 +108,12 @@ except s3.exceptions.BucketAlreadyOwnedByYou:
 ### 4.2 Upload File
 
 ```python
-s3.upload_file('hello.txt', bucket_name, 'hello.txt')
+s3.upload_file('/path/to/hello.txt', bucket_name, 'hello.txt')
 print('File uploaded.')
+```
+
+```text
+File uploaded.
 ```
 
 ---
@@ -98,6 +125,10 @@ s3.download_file(bucket_name, 'hello.txt', 'hello-downloaded.txt')
 print('File downloaded.')
 ```
 
+```text
+File downloaded.
+```
+
 ---
 
 ### 4.4 List Objects
@@ -105,7 +136,11 @@ print('File downloaded.')
 ```python
 response = s3.list_objects_v2(Bucket=bucket_name)
 for obj in response.get('Contents', []):
- print(f"- {obj['Key']} ({obj['Size']} bytes)")
+    print(f"- {obj['Key']} ({obj['Size']} bytes)")
+```
+
+```text
+- hello.txt (12 bytes)
 ```
 
 ---
@@ -120,6 +155,11 @@ s3.delete_bucket(Bucket=bucket_name)
 print('Bucket deleted.')
 ```
 
+```text
+Object deleted.
+Bucket deleted.
+```
+
 ---
 
 ## 5. Advanced Features
@@ -130,30 +170,34 @@ print('Bucket deleted.')
 
 ```python
 url = s3.generate_presigned_url(
- ClientMethod='get_object',
- Params={'Bucket': bucket_name, 'Key': 'hello.txt'},
- ExpiresIn=600 # 10 minutes validity
+    ClientMethod='get_object',
+    Params={'Bucket': bucket_name, 'Key': 'hello.txt'},
+    ExpiresIn=600,  # 10 minutes validity
 )
 
 print('Presigned GET URL:', url)
+```
+
+```text
+Presigned GET URL: http://localhost:9000/my-bucket/hello.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&...
 ```
 
 #### 5.1.2 Upload Link (PUT)
 
 ```python
 url = s3.generate_presigned_url(
- ClientMethod='put_object',
- Params={'Bucket': bucket_name, 'Key': 'upload-by-url.txt'},
- ExpiresIn=600
+    ClientMethod='put_object',
+    Params={'Bucket': bucket_name, 'Key': 'upload-by-url.txt'},
+    ExpiresIn=600,
 )
 
 print('Presigned PUT URL:', url)
 ```
 
-You can use `curl` tool to upload:
+You can use the `curl` tool to upload:
 
 ```bash
-curl -X PUT --upload-file hello.txt "http://..."
+curl -X PUT --upload-file /path/to/hello.txt "http://localhost:9000/my-bucket/upload-by-url.txt?X-Amz-Algorithm=..."
 ```
 
 ---
@@ -163,11 +207,9 @@ curl -X PUT --upload-file hello.txt "http://..."
 Suitable for files larger than 10 MB, allows manual control of each part.
 
 ```python
-import os
-
 file_path = 'largefile.bin'
 key = 'largefile.bin'
-part_size = 5 * 1024 * 1024 # 5 MB
+part_size = 5 * 1024 * 1024  # 5 MB
 
 # 1. Start upload
 response = s3.create_multipart_upload(Bucket=bucket_name, Key=key)
@@ -175,38 +217,45 @@ upload_id = response['UploadId']
 parts = []
 
 try:
- with open(file_path, 'rb') as f:
- part_number = 1
- while True:
- data = f.read(part_size)
- if not data:
- break
+    with open(file_path, 'rb') as f:
+        part_number = 1
+        while True:
+            data = f.read(part_size)
+            if not data:
+                break
 
- part = s3.upload_part(
- Bucket=bucket_name,
- Key=key,
- PartNumber=part_number,
- UploadId=upload_id,
- Body=data
- )
+            part = s3.upload_part(
+                Bucket=bucket_name,
+                Key=key,
+                PartNumber=part_number,
+                UploadId=upload_id,
+                Body=data,
+            )
 
- parts.append({'ETag': part['ETag'], 'PartNumber': part_number})
- print(f'Uploaded part {part_number}')
- part_number += 1
+            parts.append({'ETag': part['ETag'], 'PartNumber': part_number})
+            print(f'Uploaded part {part_number}')
+            part_number += 1
 
- # 2. Complete upload
- s3.complete_multipart_upload(
- Bucket=bucket_name,
- Key=key,
- UploadId=upload_id,
- MultipartUpload={'Parts': parts}
- )
- print('Multipart upload complete.')
+    # 2. Complete upload
+    s3.complete_multipart_upload(
+        Bucket=bucket_name,
+        Key=key,
+        UploadId=upload_id,
+        MultipartUpload={'Parts': parts},
+    )
+    print('Multipart upload complete.')
 
 except Exception as e:
- # Abort upload
- s3.abort_multipart_upload(Bucket=bucket_name, Key=key, UploadId=upload_id)
- print('Multipart upload aborted due to error:', e)
+    # Abort upload
+    s3.abort_multipart_upload(Bucket=bucket_name, Key=key, UploadId=upload_id)
+    print('Multipart upload aborted due to error:', e)
+```
+
+```text
+Uploaded part 1
+Uploaded part 2
+Uploaded part 3
+Multipart upload complete.
 ```
 
 ---
@@ -218,7 +267,7 @@ except Exception as e:
 | `SignatureDoesNotMatch` | Not using v4 signature | Set `signature_version='s3v4'` |
 | `EndpointConnectionError` | Wrong RustFS address or service not started | Check endpoint and RustFS service status |
 | `AccessDenied` | Wrong credentials or insufficient permissions | Check AccessKey/SecretKey or bucket policies |
-| `PermanentRedirect` | Path-style not enabled | Boto3 defaults to virtual-host, RustFS only supports path-style, but setting endpoint can bypass |
+| `PermanentRedirect` / wrong bucket URL | Path-style not enabled | Set `s3={'addressing_style': 'path'}` in the `Config` |
 
 ---
 
@@ -226,10 +275,13 @@ except Exception as e:
 
 ```python
 def upload_file(local_path, bucket, object_key):
- s3.upload_file(local_path, bucket, object_key)
- print(f"Uploaded {local_path} to s3://{bucket}/{object_key}")
+    s3.upload_file(local_path, bucket, object_key)
+    print(f"Uploaded {local_path} to s3://{bucket}/{object_key}")
+
 
 def download_file(bucket, object_key, local_path):
- s3.download_file(bucket, object_key, local_path)
- print(f"Downloaded s3://{bucket}/{object_key} to {local_path}")
+    s3.download_file(bucket, object_key, local_path)
+    print(f"Downloaded s3://{bucket}/{object_key} to {local_path}")
 ```
+
+For other operations (object tagging, bucket policies, and more), see the [Boto3 S3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html) — every S3-compatible call works against RustFS the same way.

--- a/content/developer/sdk/rust.md
+++ b/content/developer/sdk/rust.md
@@ -1,20 +1,51 @@
 ---
 title: "Rust SDK Guide"
-description: "Operating RustFS instances through Rust SDK, including creation and deletion of buckets and objects."
+description: "Operate RustFS instances through the AWS SDK for Rust, including creation and deletion of buckets and objects."
 ---
 
-RustFS is fully S3-compatible. You can use the official AWS SDK for Rust. Through the SDK, you can operate RustFS, including creation and deletion of buckets/objects, file upload and download, etc.
+RustFS ships no first-party Rust client crate — it is fully S3-compatible, so you use the official AWS SDK for Rust (`aws-sdk-s3`) configured to point at your RustFS server. Through the SDK, you can operate RustFS, including creation and deletion of buckets/objects, file upload and download, etc.
 
 ## Prerequisites
 
-- An available RustFS instance (refer to [Installation Guide](../../installation/index.md)).
-- Access keys (refer to [Access Key Management](../../administration/iam/access-token.md)).
+- Rust 1.78 or later (install via [rustup](https://rustup.rs/))
+- An available RustFS instance (refer to [Installation Guide](../../installation/index.md)) — the S3 API listens on port `9000`, the Console on port `9001`
+- Access keys, set at install time via the `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` environment variables (refer to [Access Key Management](../../administration/iam/access-token.md))
+
+:::tip[Local test]
+
+If you did not set credentials at install time, the server defaults to `rustfsadmin` / `rustfsadmin` — fine for a throwaway local trial, never for anything reachable by others.
+
+:::
+
+Create a project and add the dependencies:
+
+```bash
+cargo new rustfs-rust-demo && cd rustfs-rust-demo
+cargo add aws-config aws-sdk-s3 anyhow
+cargo add tokio --features full
+```
+
+Your `Cargo.toml` should contain:
+
+```toml title="Cargo.toml"
+[dependencies]
+anyhow = "1"
+aws-config = "1"
+aws-sdk-s3 = "1"
+tokio = { version = "1", features = ["full"] }
+```
 
 ## Initializing the Client
 
-Create a configuration struct and load credentials from environment variables:
+The following is a complete, runnable program. It loads the connection settings from environment variables, initializes the S3 client, and lists your buckets:
 
-```rust
+```rust title="src/main.rs"
+use anyhow::Result;
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::config::{Credentials, Region};
+use aws_sdk_s3::Client;
+use std::env;
+
 pub struct Config {
     pub region: String,
     pub access_key_id: String,
@@ -37,43 +68,72 @@ impl Config {
         })
     }
 }
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let config = Config::from_env()?;
+
+    let credentials = Credentials::new(
+        config.access_key_id,
+        config.secret_access_key,
+        None,
+        None,
+        "rustfs",
+    );
+
+    let region = Region::new(config.region);
+
+    let shared_config = aws_config::defaults(BehaviorVersion::latest())
+        .region(region)
+        .credentials_provider(credentials)
+        .endpoint_url(config.endpoint_url)
+        .load()
+        .await;
+
+    // RustFS uses path-style URLs by default; virtual-host style requires RUSTFS_SERVER_DOMAINS
+    let s3_config = aws_sdk_s3::config::Builder::from(&shared_config)
+        .force_path_style(true)
+        .build();
+
+    let rustfs_client = Client::from_conf(s3_config);
+
+    let res = rustfs_client.list_buckets().send().await?;
+    for bucket in res.buckets() {
+        println!("Bucket: {:?}", bucket.name());
+    }
+
+    Ok(())
+}
 ```
 
-Initialize the S3 client:
+:::note
 
-```rust
-let config = Config::from_env()?;
+These environment variable names (`RUSTFS_ENDPOINT_URL`, `RUSTFS_REGION`, `RUSTFS_ACCESS_KEY_ID`, `RUSTFS_SECRET_ACCESS_KEY`) are just this example's client-side conventions — they are read by your program, not by RustFS. They are distinct from the server-side `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` variables used when installing RustFS.
 
-let credentials = Credentials::new(
-    config.access_key_id,
-    config.secret_access_key,
-    None,
-    None,
-    "rustfs",
-);
+:::
 
-let region = Region::new(config.region);
+Run it (replace `localhost` with your server's IP address if RustFS runs on another machine):
 
-let endpoint_url = config.endpoint_url;
-
-let shard_config = aws_config::defaults(BehaviorVersion::latest())
-    .region(region)
-    .credentials_provider(credentials)
-    .endpoint_url(endpoint_url)
-    .load()
-    .await;
-
-let rustfs_client = Client::new(&shard_config);
+```bash
+export RUSTFS_ENDPOINT_URL="http://localhost:9000"
+export RUSTFS_REGION="us-east-1"
+export RUSTFS_ACCESS_KEY_ID="<your-access-key>"
+export RUSTFS_SECRET_ACCESS_KEY="<your-secret-key>"
+cargo run
 ```
 
-You can now use the client for operations.
+```text
+Bucket: Some("my-bucket")
+```
+
+You can now use the client for the operations below. Each snippet runs inside `main`, reusing `rustfs_client`.
 
 ## Create Bucket
 
 ```rust
 match rustfs_client
     .create_bucket()
-    .bucket("your-bucket-name")
+    .bucket("my-bucket")
     .send()
     .await
 {
@@ -87,12 +147,16 @@ match rustfs_client
 }
 ```
 
+```text
+Bucket created successfully
+```
+
 ## Delete Bucket
 
 ```rust
 match rustfs_client
     .delete_bucket()
-    .bucket("cn-east-1rust-sdk")
+    .bucket("my-bucket")
     .send()
     .await
 {
@@ -104,6 +168,10 @@ match rustfs_client
         return Err(e.into());
     }
 }
+```
+
+```text
+Bucket deleted successfully
 ```
 
 ## List Buckets
@@ -123,12 +191,17 @@ match rustfs_client.list_buckets().send().await {
 }
 ```
 
+```text
+Total buckets number is 1
+Bucket: Some("my-bucket")
+```
+
 ## List Objects
 
 ```rust
 match rustfs_client
     .list_objects_v2()
-    .bucket("rust-sdk-demo")
+    .bucket("my-bucket")
     .send()
     .await
 {
@@ -145,15 +218,29 @@ match rustfs_client
 }
 ```
 
+```text
+Total objects number is 1
+Object: Some("hello.txt")
+```
+
 ## Upload File
 
+Add these imports at the top of `src/main.rs`:
+
 ```rust
-let data = fs::read("/file-path/1.txt").await.expect("can not open the file");
+use aws_sdk_s3::primitives::ByteStream;
+use tokio::fs;
+```
+
+Then upload a local file:
+
+```rust
+let data = fs::read("/path/to/hello.txt").await.expect("can not open the file");
 
 match rustfs_client
     .put_object()
-    .bucket("rust-sdk-demo")
-    .key("1.txt")
+    .bucket("my-bucket")
+    .key("hello.txt")
     .body(ByteStream::from(data))
     .send()
     .await
@@ -168,18 +255,23 @@ match rustfs_client
 }
 ```
 
+```text
+Object uploaded successfully, res: PutObjectOutput { e_tag: Some("\"...\""), ... }
+```
+
 ## Download Object
 
 ```rust
 match rustfs_client
     .get_object()
-    .bucket("rust-sdk-demo")
-    .key("1.txt")
+    .bucket("my-bucket")
+    .key("hello.txt")
     .send()
     .await
 {
     Ok(res) => {
-        println!("Object downloaded successfully, res: {:?}", res);
+        let data = res.body.collect().await?.into_bytes();
+        println!("Object content: {}", String::from_utf8_lossy(&data));
     }
     Err(e) => {
         println!("Error downloading object: {:?}", e);
@@ -188,4 +280,8 @@ match rustfs_client
 }
 ```
 
-For other usage, you can explore on your own. If you use Vibe Coding, it becomes even simpler!
+```text
+Object content: hello rustfs
+```
+
+For other operations (presigned URLs, multipart uploads, and more), see the [AWS SDK for Rust documentation](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/) — every S3-compatible call works against RustFS the same way.

--- a/content/developer/sdk/typescript.md
+++ b/content/developer/sdk/typescript.md
@@ -1,129 +1,204 @@
 ---
 title: "RustFS TypeScript SDK Usage Guide"
-description: "Operating RustFS instances through TypeScript SDK, including creation and deletion of buckets and objects."
+description: "Operate RustFS from TypeScript with the AWS SDK for JavaScript v3, including creation and deletion of buckets and objects."
 ---
 
-Since RustFS is a fully S3-compatible object storage system, you can build a TypeScript SDK suitable for RustFS by wrapping the S3 TypeScript SDK. Through the SDK, you can operate RustFS, including creation and deletion of buckets/objects, file upload and download, etc.
+RustFS ships no first-party TypeScript SDK — it is fully S3-compatible, so you use the official AWS SDK for JavaScript v3 (which ships its own TypeScript type definitions) configured to point at your RustFS server. Through the SDK, you can operate RustFS, including creation and deletion of buckets/objects, file upload and download, etc.
 
 ## Prerequisites
 
-- An available RustFS instance (refer to [Installation Guide](../../installation/index.md) for installation).
-- Access keys (refer to [Access Key Management](../../administration/iam/access-token.md) for creation).
+- Node.js 18 or later (the examples use ES modules — set `"type": "module"` in your `package.json`)
+- An available RustFS instance (refer to [Installation Guide](../../installation/index.md) for installation) — the S3 API listens on port `9000`, the Console on port `9001`
+- Access keys, set at install time via the `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` environment variables (refer to [Access Key Management](../../administration/iam/access-token.md) for creation)
 
-## RustFS TypeScript SDK Construction
+:::tip[Local test]
 
-Using TypeScript's S3Client, construct a RustFS client with `region`, `access_key_id`, `secret_access_key`, and `endpoint_url`:
+If you did not set credentials at install time, the server defaults to `rustfsadmin` / `rustfsadmin` — fine for a throwaway local trial, never for anything reachable by others.
 
-```typescript
-const rustfs_client = new S3Client({
-    region: "cn-east-1",
-    credentials: {
-        accessKeyId: process.env.RUSTFS_ACCESS_KEY_ID!,
-        secretAccessKey: process.env.RUSTFS_SECRET_ACCESS_KEY!,
-    },
-    endpoint: process.env.RUSTFS_ENDPOINT_URL!,
-});
+:::
+
+Install the dependencies:
+
+```bash
+npm install @aws-sdk/client-s3
+npm install --save-dev typescript tsx @types/node
 ```
 
-Then use the constructed `rustfs_client` for corresponding operations.
+## Initializing the Client
+
+The following is a complete, runnable example. Replace `localhost` with your server's IP address if RustFS runs on another machine, and fill in your own access keys:
+
+```typescript title="main.ts"
+import {
+  S3Client,
+  CreateBucketCommand,
+  DeleteBucketCommand,
+  ListBucketsCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  GetObjectCommand,
+} from "@aws-sdk/client-s3";
+import * as fs from "fs";
+
+const rustfs_client = new S3Client({
+  region: "us-east-1", // RustFS default region
+  endpoint: "http://localhost:9000", // RustFS S3 API address
+  credentials: {
+    accessKeyId: "<your-access-key>",
+    secretAccessKey: "<your-secret-key>",
+  },
+  // RustFS uses path-style URLs by default; virtual-host style requires RUSTFS_SERVER_DOMAINS
+  forcePathStyle: true,
+});
+
+const response = await rustfs_client.send(new ListBucketsCommand({}));
+console.log(response.Buckets?.map((bucket) => bucket.Name) ?? []);
+```
+
+Run it:
+
+```bash
+npx tsx main.ts
+```
+
+```text
+[ 'my-bucket' ]
+```
+
+Then use the constructed `rustfs_client` for the operations below.
 
 ## Create Bucket
 
 ```typescript
 async function createBucket() {
-    try {
-        const response = await rustfs_client.send(new CreateBucketCommand({
-            Bucket: "my-bucket",
-        }));
-        console.log(response);
-    } catch (error) {
-        console.log(error);
-    }
+  try {
+    const response = await rustfs_client.send(
+      new CreateBucketCommand({
+        Bucket: "my-bucket",
+      })
+    );
+    console.log("Bucket created:", response.Location);
+  } catch (error) {
+    console.log(error);
+  }
 }
+```
+
+```text
+Bucket created: /my-bucket
 ```
 
 ## Delete Bucket
 
 ```typescript
 async function deleteBucket() {
-    try {
-        const response = await rustfs_client.send(new DeleteBucketCommand({
-            Bucket: "my-bucket",
-        }));
-        console.log(response);
-    } catch (error) {
-        console.log(error);
-    }
+  try {
+    await rustfs_client.send(
+      new DeleteBucketCommand({
+        Bucket: "my-bucket",
+      })
+    );
+    console.log("Bucket deleted");
+  } catch (error) {
+    console.log(error);
+  }
 }
+```
+
+```text
+Bucket deleted
 ```
 
 ## List Buckets
 
 ```typescript
 async function listBuckets() {
-    try {
-        const response = await rustfs_client.send(new ListBucketsCommand({}));
-        console.log(response);
-    } catch (error) {
-        console.log(error);
-    }
+  try {
+    const response = await rustfs_client.send(new ListBucketsCommand({}));
+    response.Buckets?.forEach((bucket) => console.log(bucket.Name));
+  } catch (error) {
+    console.log(error);
+  }
 }
+```
+
+```text
+my-bucket
 ```
 
 ## List Objects
 
 ```typescript
 async function listObjects() {
-    try {
-        const response = await rustfs_client.send(new ListObjectsV2Command({
-            Bucket: "rust-sdk-demo",
-        }));
-        console.log(response);
-    } catch (error) {
-        console.log(error);
-    }
+  try {
+    const response = await rustfs_client.send(
+      new ListObjectsV2Command({
+        Bucket: "my-bucket",
+      })
+    );
+    response.Contents?.forEach((obj) => console.log(`${obj.Key} (${obj.Size} bytes)`));
+  } catch (error) {
+    console.log(error);
+  }
 }
+```
+
+```text
+test/hello.txt (12 bytes)
 ```
 
 ## Upload File
 
 ```typescript
 async function uploadFile() {
-    try {
-        const response = await rustfs_client.send(new PutObjectCommand({
-            Bucket: "my-bucket",
-            Key: "/test/1.txt",
-            Body: fs.createReadStream("/Users/jhma/Desktop/1.txt"),
-        }));
-    } catch (error) {
-        console.log(error);
-    }
+  try {
+    await rustfs_client.send(
+      new PutObjectCommand({
+        Bucket: "my-bucket",
+        Key: "test/hello.txt",
+        Body: fs.createReadStream("/path/to/hello.txt"),
+      })
+    );
+    console.log("Object uploaded");
+  } catch (error) {
+    console.log(error);
+  }
 }
+```
+
+```text
+Object uploaded
 ```
 
 ## Download Object
 
 ```typescript
 async function getObject() {
-    try {
-        const response = await rustfs_client.send(new GetObjectCommand({
-            Bucket: "rust-sdk-demo",
-            Key: "1.txt",
-        }));
+  try {
+    const response = await rustfs_client.send(
+      new GetObjectCommand({
+        Bucket: "my-bucket",
+        Key: "test/hello.txt",
+      })
+    );
 
-        // get object content
-        if (response.Body) {
-            const chunks: Buffer[] = [];
-            for await (const chunk of response.Body as any) {
-                chunks.push(chunk as Buffer);
-            }
-            const data = Buffer.concat(chunks).toString("utf-8");
-            console.log("Object content:", data);
-        }
-    } catch (error) {
-        console.log(error);
+    // get object content
+    if (response.Body) {
+      const chunks: Buffer[] = [];
+      for await (const chunk of response.Body as any) {
+        chunks.push(chunk as Buffer);
+      }
+      const data = Buffer.concat(chunks).toString("utf-8");
+      console.log("Object content:", data);
     }
+  } catch (error) {
+    console.log(error);
+  }
 }
 ```
 
-For other usage, you can explore on your own. If you use Vibe Coding, it becomes even simpler!
+```text
+Object content: hello rustfs
+```
+
+For other operations (presigned URLs, multipart uploads, and more), see the [AWS SDK for JavaScript v3 documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/) — every S3-compatible call works against RustFS the same way.


### PR DESCRIPTION
## Summary (review workstream: SDK guides — rustfs/backlog#1271, all items)

All six SDK guides (Java, Python, Go, Rust, JavaScript, TypeScript) now meet a copy-paste-runnable standard:

- First example on every page is a complete runnable program: dependency install + full imports/scaffolding (Rust includes Cargo.toml; Go includes go mod; TS includes a tsx run command)
- **Added the missing path-style configuration to Rust and TypeScript** — without it, requests to IP endpoints fail; Java presigner gets `pathStyleAccessEnabled`
- **Fixed Python indentation across the page** (the multipart section was a SyntaxError); every Python block now passes `ast.parse`
- Unified constants: `http://localhost:9000`, `us-east-1`, `my-bucket`, placeholder credentials; expected output after key operations
- Removed leftover LLM conversation text and "Vibe Coding" endings; repeated notes converted to callouts

Build: ✓ 359 pages.

---
Backed by the multi-role docs review (master issue rustfs/backlog#1277; six full reports ship in the nav PR under `docs-review/`). Technical facts verified against rustfs/rustfs@ea2e24ac.

## Rendered page previews (before / after)

<details><summary><code>/developer/sdk/go</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/developer__sdk__go.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/sdk/developer__sdk__go.png) |

</details>
<details><summary><code>/developer/sdk/java</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/developer__sdk__java.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/sdk/developer__sdk__java.png) |

</details>
<details><summary><code>/developer/sdk/javascript</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/developer__sdk__javascript.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/sdk/developer__sdk__javascript.png) |

</details>
<details><summary><code>/developer/sdk/python</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/developer__sdk__python.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/sdk/developer__sdk__python.png) |

</details>
<details><summary><code>/developer/sdk/rust</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/developer__sdk__rust.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/sdk/developer__sdk__rust.png) |

</details>
<details><summary><code>/developer/sdk/typescript</code></summary>

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/main/developer__sdk__typescript.png) | ![after](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/sdk/developer__sdk__typescript.png) |

</details>
