### PR TITLE
docs: add Reference pages (env vars / CLI / ports) and real S3 compatibility matrix

### DIFF
--- a/content/features/s3-compatibility/index.md
+++ b/content/features/s3-compatibility/index.md
@@ -1,59 +1,79 @@
 ---
-title: "Amazon S3 Compatibility"
-description: "S3 compatibility is essential for cloud-native applications. RustFS strictly adheres to S3 API standards. RustFS offers a widely tested S3 alternative."
+title: "S3 Compatibility"
+description: "The RustFS S3 compatibility matrix: which S3 APIs are implemented, which are planned, and which are intentionally out of scope, backed by the executable Ceph s3tests suites."
 ---
 
-S3 compatibility is essential for cloud-native applications. RustFS strictly adheres to S3 API standards. RustFS offers a widely tested S3 alternative.
+RustFS provides broad S3 API compatibility for supported features. It does not claim complete coverage of every standard or vendor-specific S3 behavior. This page reproduces the upstream [S3 compatibility matrix](https://github.com/rustfs/rustfs/blob/main/docs/architecture/s3-compatibility-matrix.md), which ties the compatibility claim to the executable Ceph s3tests lists under `scripts/s3-tests/` in the RustFS repository.
 
-## RustFS and S3 API - Designed for Multi-Cloud Storage
+Legend: ✅ implemented and gated by tests · ❌ planned but not yet implemented · ⊘ intentionally excluded (out of scope).
 
-RustFS prioritizes S3 compatibility. As an early adopter of the S3 API (V2 and V4), RustFS ensures compatibility across public cloud, private cloud, data center, multi-cloud, hybrid cloud, and edge environments.
+## Test list sources
 
-## S3 Enables Hybrid and Multi-Cloud Computing
+| List | Purpose | Count | Source |
+| --- | --- | ---: | --- |
+| Implemented tests | Standard S3 tests expected to pass; used by the default local s3tests run. | 452 | `scripts/s3-tests/implemented_tests.txt` |
+| Lifecycle behavior tests | Expiration behavior cases gated by the dedicated lifecycle lane (debug-accelerated day + scanner enabled). | 5 | `scripts/s3-tests/lifecycle_behavior_tests.txt` |
+| Unimplemented tests | Standard S3 features planned but not yet implemented. | 17 | `scripts/s3-tests/unimplemented_tests.txt` |
+| Excluded tests | Vendor-specific or intentionally unsupported behavior excluded from compatibility gating. | 273 | `scripts/s3-tests/excluded_tests.txt` |
 
-S3 is the standard for multi-cloud compatibility. As a RESTful API standard, S3 facilitates interactions between applications, data, and infrastructure.
+Counts ignore blank lines and comments.
 
-Kubernetes-native, S3-compatible object storage and applications can run anywhere - from public cloud instances (Google, Azure, AWS) to private clouds (Red Hat OpenShift, VMware Tanzu) and bare metal.
+## Supported coverage
 
-## S3 Compatibility for Bare Metal Workloads
+The implemented test list currently covers the common object-storage surface:
 
-Private cloud is a fundamental building block of hybrid cloud architecture. S3 compatibility is crucial for all applications, from analytics to archiving.
+### Bucket APIs
 
-With RustFS, S3 compatibility is location-independent. RustFS bare metal instances have the same S3 compatibility and performance as public cloud or edge instances.
+| Area | Status |
+| --- | --- |
+| Bucket create / delete / list / head | ✅ |
+| Bucket and object tagging | ✅ |
+| Bucket policy put / get / delete | ✅ |
+| Public access block put / get / delete | ✅ |
 
-## Advantages of RustFS Scalable Object Storage
+### Object APIs
 
-Cloud-native applications use the S3 API to communicate with object storage. Many vendors only support a subset of functionality.
+| Area | Status |
+| --- | --- |
+| Object put / get / delete / copy / head | ✅ |
+| ListObjects / ListObjectsV2 with prefix, delimiter, marker, max-keys | ✅ |
+| Presigned GET and PUT URLs | ✅ |
+| Range and conditional reads | ✅ |
+| User metadata | ✅ |
+| SSE-C and selected SSE-KMS edge cases | ✅ |
+| Selected versioning, object-lock, checksum, CORS, raw request, and conditional write behavior | ✅ |
 
-RustFS has a proven track record of S3 compatibility. We test millions of hardware, software, and application combinations. RustFS releases software weekly, and community-reported defects are promptly addressed.
+### Multipart APIs
 
-Comprehensive S3 API support means applications can leverage data stored in RustFS on any hardware, location, or cloud.
+| Area | Status |
+| --- | --- |
+| Multipart upload create / upload / complete / abort | ✅ |
+| Selected multipart copy, checksum, and object-attribute behavior | ✅ |
 
-## Core Features
+## Planned standard coverage
 
-### S3 Select
+These are standard S3 areas that remain planned work and are not yet complete:
 
-![S3 Select](images/s1-4.png)
+| Area | Status | Evidence |
+| --- | --- | --- |
+| Bucket access logging | ❌ | `unimplemented_tests.txt` |
+| POST Object form upload checksum handling | ❌ | `unimplemented_tests.txt` |
+| Bucket ownership controls | ❌ | `unimplemented_tests.txt` |
+| IAM-account or multi-storage-class dependent cases | ❌ | `unimplemented_tests.txt` |
+| Tenanted bucket policy edge cases | ❌ (needs investigation) | `unimplemented_tests.txt` |
+| Multipart upload listing and part lookup compatibility edge cases | ⊘ (not part of default gate) | `excluded_tests.txt` |
 
-S3 Select relies on performance for complex queries. RustFS leverages SIMD instruction sets to optimize performance, running complex S3 Select queries on CSV, Parquet, JSON, and more.
+## Intentional exclusions
 
-### Amazon Signature V4
+The excluded list contains tests that do not block the RustFS compatibility gate. They fall into two classes:
 
-```mermaid
-flowchart LR
-    A1["1. Create canonical request"]
-    A2["2. Create string to sign"]
-    A3["3. Calculate signature"]
-    A4["4. Add signature to request"]
-    A1 --> A2 --> A3 --> A4
-    classDef svc fill:#eef2ff,stroke:#6366f1,stroke-width:2px,color:#1e293b;
-    class A1,A2,A3,A4 svc
-```
+- vendor-specific or non-portable behavior not required for RustFS S3 compatibility;
+- intentionally unsupported product behavior, such as ACL authorization.
 
-Applications and clients must authenticate to access RustFS management APIs. RustFS supports AWS Signature Version 4. After authentication, RustFS uses policy-based access control compatible with AWS IAM to authorize operations.
+## Lifecycle behavior lane
 
-## AWS S3 API and RustFS
+The lifecycle behavior lane runs real Days-based expiration cases. It requires `RUSTFS_ILM_DEBUG_DAY_SECS` (the Ceph `lc_debug_interval` equivalent) and an enabled background scanner, and runs separately from the default single-server gate because a global debug day would also shrink the `x-amz-expiration` header asserted by other lifecycle header tests.
 
-RustFS is a high-performance object storage. Combined with S3 compatibility, it supports a wide set of use cases, including code repositories (GitHub, GitLab), analytics (MongoDB, ClickHouse, MariaDB, CockroachDB, Teradata), and archiving/backup.
-
-RustFS is ideal for AI/ML and data science workloads. KubeFlow and TensorFlow require high-performance S3-compatible object storage. RustFS provides multi-cloud object storage and efficient replication.
+:::note
+For the authoritative, always-current test lists and the update rule that moves entries from unimplemented to implemented, see the upstream matrix: [docs/architecture/s3-compatibility-matrix.md](https://github.com/rustfs/rustfs/blob/main/docs/architecture/s3-compatibility-matrix.md).
+:::

--- a/content/reference/cli.md
+++ b/content/reference/cli.md
@@ -1,0 +1,104 @@
+---
+title: "CLI Reference"
+description: "Reference for the rustfs command-line interface, including the server, info, and tls subcommands, key flags with environment variable equivalents, and volume path syntax."
+---
+
+The `rustfs` binary ships three subcommands. Running `rustfs` with no subcommand starts the server.
+
+## Subcommands
+
+| Command | Description |
+| --- | --- |
+| `rustfs server [OPTIONS] <VOLUMES>...` | Start the object storage server (default when no subcommand is given). |
+| `rustfs info [--all] [--json] [system\|runtime\|build\|config\|deps]` | Display system, runtime, build, configuration, or dependency information. |
+| `rustfs tls inspect --path <DIR>` | Inspect a TLS certificate directory layout and parsing status. |
+
+```bash title="Examples"
+rustfs server /data/rustfs
+rustfs info --all --json
+rustfs tls inspect --path /etc/rustfs/tls
+```
+
+### Legacy invocation compatibility
+
+Arguments are preprocessed for backward compatibility, so older invocation styles keep working:
+
+| Legacy form | Interpreted as |
+| --- | --- |
+| `rustfs /data` | `rustfs server /data` |
+| `rustfs --address :9000 /data` | `rustfs server --address :9000 /data` |
+| `rustfs` (no arguments) | `rustfs server` with volumes read from `RUSTFS_VOLUMES` |
+| `rustfs --info` | `rustfs info` |
+| `rustfs help` | `rustfs --help` |
+
+## Server flags
+
+Every server flag has an environment variable equivalent; the flag wins when both are set.
+
+| Flag | Environment variable | Default | Description |
+| --- | --- | --- | --- |
+| `<VOLUMES>...` (positional) | `RUSTFS_VOLUMES` | required | Storage volumes or endpoints, space-separated. |
+| `--address` | `RUSTFS_ADDRESS` | `:9000` | S3 API bind address (`ADDRESS:PORT`, IP or hostname). |
+| `--server-domains` | `RUSTFS_SERVER_DOMAINS` | unset | Comma-separated domains for virtual-hosted-style requests. |
+| `--access-key` | `RUSTFS_ACCESS_KEY` | unset | Root access key (conflicts with `--access-key-file`). |
+| `--access-key-file` | `RUSTFS_ACCESS_KEY_FILE` | unset | File containing the root access key. |
+| `--secret-key` | `RUSTFS_SECRET_KEY` | unset | Root secret key (conflicts with `--secret-key-file`). |
+| `--secret-key-file` | `RUSTFS_SECRET_KEY_FILE` | unset | File containing the root secret key. |
+| `--console-enable` | `RUSTFS_CONSOLE_ENABLE` | `true` | Enable the embedded web console. |
+| `--console-address` | `RUSTFS_CONSOLE_ADDRESS` | `:9001` | Console bind address. |
+| `--obs-endpoint` | `RUSTFS_OBS_ENDPOINT` | empty | OTLP/HTTP base URL for traces, metrics, and logs. |
+| `--tls-path` | `RUSTFS_TLS_PATH` | unset | TLS certificate directory for the API and console. |
+| `--license` | `RUSTFS_LICENSE` | unset | License string. |
+| `--region` | `RUSTFS_REGION` | unset | Service region reported to clients. |
+| `--kms-enable` | `RUSTFS_KMS_ENABLE` | `false` | Enable KMS server-side encryption. |
+| `--kms-backend` | `RUSTFS_KMS_BACKEND` | `local` | KMS backend: `local`, `vault` / `vault-kv2`, `vault-transit`. |
+| `--kms-key-dir` | `RUSTFS_KMS_KEY_DIR` | unset | Key directory for the local KMS backend. |
+| `--kms-local-master-key` | `RUSTFS_KMS_LOCAL_MASTER_KEY` | unset | Master key for local KMS key-file encryption. |
+| `--kms-vault-address` | `RUSTFS_KMS_VAULT_ADDRESS` | unset | Vault address for the Vault backends. |
+| `--kms-vault-token` | `RUSTFS_KMS_VAULT_TOKEN` | unset | Vault token for the Vault backends. |
+| `--kms-vault-mount-path` | `RUSTFS_KMS_VAULT_MOUNT_PATH` | unset | Vault mount path. |
+| `--kms-default-key-id` | `RUSTFS_KMS_DEFAULT_KEY_ID` | unset | Default KMS key ID for encryption. |
+| `--kms-allow-insecure-dev-defaults` | `RUSTFS_KMS_ALLOW_INSECURE_DEV_DEFAULTS` | `false` | Allow development-only insecure KMS defaults. |
+| `--buffer-profile` | `RUSTFS_BUFFER_PROFILE` | `GeneralPurpose` | Workload profile for adaptive buffer sizing. |
+| `--buffer-profile-disable` | `RUSTFS_BUFFER_PROFILE_DISABLE` | `false` | Use legacy fixed-size buffers. |
+
+:::note
+If neither `--access-key`/`--secret-key` nor their file variants are provided, the server falls back to the built-in default credentials (`rustfsadmin`/`rustfsadmin`) and logs a warning. Set real credentials for any non-throwaway deployment.
+:::
+
+## Volume syntax
+
+Volumes are passed as positional arguments (or via `RUSTFS_VOLUMES`) and are space-separated.
+
+### Ellipses expansion
+
+A volume token may contain one or more `{N...M}` ranges, which expand numerically:
+
+```bash title="Ellipses expansion"
+# Expands to /data/rustfs0 /data/rustfs1 /data/rustfs2 /data/rustfs3
+rustfs server /data/rustfs{0...3}
+
+# Multi-node: expands across hosts and disks
+rustfs server http://node{1...4}:9000/data/rustfs{0...3}
+```
+
+Rules verified from the parser:
+
+- The range format is `{N...M}` where `N` and `M` are decimal or hexadecimal positive integers and `M` must be greater than `N`.
+- A single token may carry multiple ranges (e.g. host range plus disk range); all combinations are expanded.
+- The maximum expanded size of one range is 10,000 entries.
+
+### Multiple pools
+
+Separate server pools are expressed as space-separated groups of endpoints. Each argument (one per space) forms its own expansion group:
+
+```bash title="Two pools"
+rustfs server http://node{1...4}:9000/data/rustfs{0...3} http://node{5...8}:9000/data/rustfs{0...3}
+```
+
+When set through the environment, the same string goes into `RUSTFS_VOLUMES`:
+
+```bash title="Via environment"
+export RUSTFS_VOLUMES="http://node{1...4}:9000/data/rustfs{0...3}"
+rustfs server
+```

--- a/content/reference/environment-variables.md
+++ b/content/reference/environment-variables.md
@@ -1,0 +1,185 @@
+---
+title: "Environment Variables"
+description: "Reference for the environment variables that configure the RustFS server, console, TLS, KMS, observability, scanner, healing, storage classes, credentials, and event targets."
+---
+
+This page lists the environment variables recognized by the `rustfs` server binary. It covers the operations-relevant subset verified against the RustFS source code; some internal tuning knobs are intentionally omitted. Every variable can also be supplied through the matching command-line flag where one exists (see the [CLI reference](./cli)).
+
+:::note
+Boolean variables accept `true`/`false`. Values shown as "unset" have no default and the corresponding feature stays disabled or falls back to built-in behavior.
+:::
+
+## Core server
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTFS_VOLUMES` | unset (required) | Storage volumes or endpoints, space-separated. Supports `{N...M}` ellipses expansion, e.g. `/data/rustfs{0...3}` or `http://node{1...4}:9000/data/rustfs{0...3}`. The Docker image defaults to `/data`. |
+| `RUSTFS_ADDRESS` | `:9000` | Bind address and port for the S3 API listener (also carries internal node RPC). |
+| `RUSTFS_SERVER_DOMAINS` | unset | Comma-separated domain name(s) for virtual-hosted-style S3 requests, e.g. `s3.example.com` so `bucket.s3.example.com` resolves to bucket `bucket`. When unset, only path-style addressing works. |
+| `RUSTFS_REGION` | unset | Region reported to S3 clients. When unset the server falls back to `us-east-1`. |
+| `RUSTFS_LICENSE` | unset | License string. |
+| `RUSTFS_BUFFER_PROFILE` | `GeneralPurpose` | Workload profile for adaptive buffer sizing. Options: `GeneralPurpose`, `AiTraining`, `DataAnalytics`, `WebWorkload`, `IndustrialIoT`, `SecureStorage`. |
+| `RUSTFS_BUFFER_PROFILE_DISABLE` | `false` | Disable adaptive buffer sizing and use legacy fixed-size buffers. |
+| `RUSTFS_HEALTH_ENDPOINT_ENABLE` | `true` | Register the unauthenticated `/health` and `/health/ready` probe endpoints. |
+| `RUSTFS_HEALTH_READINESS_CACHE_TTL_MS` | `1000` | Cache TTL for readiness probe results, in milliseconds. |
+| `RUSTFS_HEALTH_CLUSTER_TIMEOUT_MS` | `2000` | Timeout for cluster health probes (`/minio/health/cluster`), in milliseconds. |
+| `RUSTFS_STARTUP_READINESS_MAX_WAIT_SECS` | `120` | Maximum time the readiness probe reports "starting" before startup is considered failed. |
+
+## Console
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTFS_CONSOLE_ENABLE` | `true` | Enable the embedded web console (served on a separate listener). |
+| `RUSTFS_CONSOLE_ADDRESS` | `:9001` | Bind address and port for the console listener. |
+
+## TLS & KMS
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTFS_TLS_PATH` | unset | Directory containing the TLS certificate and key (`rustfs_cert.pem` / `rustfs_key.pem`) for the S3 API and console. TLS is enabled when set. |
+| `RUSTFS_TLS_RELOAD_ENABLE` | `false` | Watch the TLS directory and hot-reload certificates. |
+| `RUSTFS_TLS_KEYLOG` | `false` | Write TLS session keys to a keylog file for debugging. Do not enable in production. |
+| `RUSTFS_TRUST_SYSTEM_CA` | `false` | Also trust the operating system CA store for outbound TLS connections. |
+| `RUSTFS_TRUST_LEAF_CERT_AS_CA` | `false` | Trust a leaf certificate as if it were a CA (self-signed setups). |
+| `RUSTFS_SERVER_MTLS_ENABLE` | `false` | Require client certificates (mutual TLS) on the server listeners. |
+| `RUSTFS_MTLS_CLIENT_CERT` | unset | Client certificate presented for internode mTLS connections. |
+| `RUSTFS_MTLS_CLIENT_KEY` | unset | Client private key for internode mTLS connections. |
+| `RUSTFS_KMS_ENABLE` | `false` | Enable KMS-backed server-side encryption. |
+| `RUSTFS_KMS_BACKEND` | `local` | KMS backend: `local`, `vault` / `vault-kv2` (Vault KV2 + Transit), or `vault-transit`. |
+| `RUSTFS_KMS_KEY_DIR` | unset | Key directory for the `local` backend. |
+| `RUSTFS_KMS_LOCAL_MASTER_KEY` | unset | Master key protecting local KMS key files. |
+| `RUSTFS_KMS_VAULT_ADDRESS` | unset | Vault server address for the Vault backends. |
+| `RUSTFS_KMS_VAULT_TOKEN` | unset | Vault token for the Vault backends. |
+| `RUSTFS_KMS_VAULT_MOUNT_PATH` | unset | Vault mount path for the Vault backends. |
+| `RUSTFS_KMS_DEFAULT_KEY_ID` | unset | Default KMS key ID used for encryption. |
+| `RUSTFS_KMS_ALLOW_INSECURE_DEV_DEFAULTS` | `false` | Allow development-only insecure KMS defaults. Never enable in production. |
+
+## Observability
+
+The observability pipeline exports traces, metrics, and logs over OTLP/HTTP.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTFS_OBS_ENDPOINT` | empty | Root OTLP/HTTP base URL for traces, metrics, and logs, e.g. `http://otel-collector:4318`. When empty, logs go to stdout or local files. |
+| `RUSTFS_OBS_TRACE_ENDPOINT` | unset | Per-signal override for the traces endpoint. |
+| `RUSTFS_OBS_METRIC_ENDPOINT` | unset | Per-signal override for the metrics endpoint. |
+| `RUSTFS_OBS_LOG_ENDPOINT` | unset | Per-signal override for the logs endpoint. |
+| `RUSTFS_OBS_TRACES_EXPORT_ENABLED` | `true` | Export traces to the OTLP endpoint. |
+| `RUSTFS_OBS_METRICS_EXPORT_ENABLED` | `true` | Export metrics to the OTLP endpoint. |
+| `RUSTFS_OBS_LOGS_EXPORT_ENABLED` | `true` | Export logs to the OTLP endpoint. |
+| `RUSTFS_OBS_USE_STDOUT` | unset | Force telemetry output to stdout. |
+| `RUSTFS_OBS_SAMPLE_RATIO` | unset | Trace sampling ratio (0.0–1.0). |
+| `RUSTFS_OBS_METER_INTERVAL` | unset | Metrics export interval in seconds. |
+| `RUSTFS_OBS_SERVICE_NAME` | unset | Service name reported in telemetry resource attributes. |
+| `RUSTFS_OBS_ENVIRONMENT` | unset | Deployment environment label (`production`, `development`, `test`, `staging`). |
+| `RUSTFS_OBS_LOGGER_LEVEL` | unset | Log level filter (e.g. `info`, `debug`). |
+| `RUSTFS_OBS_LOG_STDOUT_ENABLED` | unset | Also mirror logs to stdout when file/OTLP logging is active. |
+| `RUSTFS_OBS_LOG_DIRECTORY` | unset | Local log directory. Unset means logs go to stdout; a URL value sends logs to a remote endpoint. |
+| `RUSTFS_OBS_LOG_FILENAME` | `rustfs.log` | Log filename inside the log directory. |
+| `RUSTFS_OBS_LOG_ROTATION_TIME` | `hourly` | Time-based log rotation: `daily`, `hourly`, `minutely`. |
+| `RUSTFS_OBS_LOG_KEEP_FILES` | `30` | Number of rotated log files to keep. |
+| `RUSTFS_OBS_LOG_MAX_TOTAL_SIZE_BYTES` | `2147483648` | Total size budget (2 GiB) for the log directory before cleanup. |
+| `RUSTFS_OBS_LOG_COMPRESS_OLD_FILES` | `true` | Compress rotated log files (`zstd` by default, controllable via `RUSTFS_OBS_LOG_COMPRESSION_ALGORITHM`). |
+
+Metrics collection intervals follow the pattern `RUSTFS_METRICS_<SCOPE>_INTERVAL_SEC` with scopes `DEFAULT`, `SYSTEM`, `CLUSTER`, `BUCKET`, `NODE`, `RESOURCE`, `AUDIT`, `NOTIFICATION`, and `BUCKET_REPLICATION_BANDWIDTH` — for example `RUSTFS_METRICS_CLUSTER_INTERVAL_SEC=60`.
+
+## Scanner & Healing
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTFS_SCANNER_SPEED` | `default` | Scanner speed preset: `fastest`, `fast`, `default`, `slow`, `slowest`. Controls sleep factor, max sleep, and cycle interval. |
+| `RUSTFS_SCANNER_DELAY` | preset | Overrides the scanner sleep multiplier (e.g. `30.0`). |
+| `RUSTFS_SCANNER_MAX_WAIT_SECS` | preset | Overrides the maximum scanner sleep in seconds. |
+| `RUSTFS_SCANNER_CYCLE` | preset | Overrides the scan cycle interval in seconds (e.g. `3600`). |
+| `RUSTFS_SCANNER_START_DELAY_SECS` | unset | Startup delay in seconds before the first scan cycle. |
+| `RUSTFS_SCANNER_CYCLE_MAX_DURATION_SECS` | `0` | Caps one cycle's runtime in seconds; `0` disables the budget. |
+| `RUSTFS_SCANNER_CYCLE_MAX_OBJECTS` | `0` | Caps objects processed per cycle; `0` disables the budget. |
+| `RUSTFS_SCANNER_CYCLE_MAX_DIRECTORIES` | `0` | Caps directories entered per cycle; `0` disables the budget. |
+| `RUSTFS_SCANNER_BITROT_CYCLE_SECS` | `2592000` | Periodic deep (bitrot) scan cycle in seconds (30 days). `0`/`true`/`on` makes every cycle deep; `false`/`off` disables deep scans. |
+| `RUSTFS_SCANNER_IDLE_MODE` | `true` | When `true` the scanner throttles itself; `false` runs at full speed. |
+| `RUSTFS_SCANNER_CACHE_SAVE_TIMEOUT_SECS` | `30` | Scanner cache save timeout in seconds (minimum `1`). |
+| `RUSTFS_SCANNER_MAX_CONCURRENT_SET_SCANS` | `0` | Caps concurrent erasure-set scan tasks; `0` keeps topology-based concurrency. |
+| `RUSTFS_SCANNER_MAX_CONCURRENT_DISK_SCANS` | `0` | Caps concurrent disk bucket walks per set; `0` keeps disk-count-based concurrency. |
+| `RUSTFS_SCANNER_YIELD_EVERY_N_OBJECTS` | `128` | How often scanner object loops yield to the async runtime; `0` disables the extra yield. |
+| `RUSTFS_SCANNER_ALERT_EXCESS_VERSIONS` | `100` | Object version count that triggers scanner alerts. |
+| `RUSTFS_SCANNER_ALERT_EXCESS_VERSION_SIZE` | `1099511627776` | Cumulative version bytes (1 TiB) that trigger scanner alerts. |
+| `RUSTFS_SCANNER_ALERT_EXCESS_FOLDERS` | `65538` | Direct subfolder count that triggers scanner alerts. |
+| `RUSTFS_HEAL_AUTO_HEAL_ENABLE` | `true` | Enable automatic background healing of degraded objects. |
+| `RUSTFS_HEAL_QUEUE_SIZE` | `10000` | Capacity of the heal-candidate queue. |
+| `RUSTFS_HEAL_INTERVAL_SECS` | `10` | Interval between heal scheduler runs, in seconds. |
+| `RUSTFS_HEAL_TASK_TIMEOUT_SECS` | `300` | Timeout for a single heal task, in seconds. |
+| `RUSTFS_HEAL_MAX_CONCURRENT_HEALS` | `4` | Maximum concurrent heal tasks. |
+| `RUSTFS_HEAL_MAX_CONCURRENT_PER_SET` | `1` | Maximum concurrent heal tasks per erasure set. |
+
+## Storage & Erasure
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTFS_STORAGE_CLASS_STANDARD` | auto | Parity for the STANDARD storage class in `EC:n` format, e.g. `EC:4`. When unset, parity is derived from the erasure set size. |
+| `RUSTFS_STORAGE_CLASS_RRS` | `EC:1` | Parity for the REDUCED_REDUNDANCY storage class in `EC:n` format. |
+| `RUSTFS_STORAGE_CLASS_OPTIMIZE` | `availability` | Optimization goal for parity selection. |
+| `RUSTFS_STORAGE_CLASS_INLINE_BLOCK` | `131072` | Threshold (128 KiB) below which object data is inlined into metadata. |
+| `RUSTFS_ERASURE_SET_DRIVE_COUNT` | `0` | Force the number of drives per erasure set; `0` selects the layout automatically. |
+| `RUSTFS_DURABILITY_MODE` | unset | Write durability mode: `strict`, `relaxed`, or `none`. Takes precedence over the legacy drive-sync switch when set to a valid value. |
+
+## Credentials & Internal
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTFS_ACCESS_KEY` | `rustfsadmin` | Root access key. Mutually exclusive with `RUSTFS_ACCESS_KEY_FILE`. |
+| `RUSTFS_SECRET_KEY` | `rustfsadmin` | Root secret key. Mutually exclusive with `RUSTFS_SECRET_KEY_FILE`. |
+| `RUSTFS_ACCESS_KEY_FILE` | unset | Path to a file containing the access key (e.g. a Docker/Kubernetes secret mount). |
+| `RUSTFS_SECRET_KEY_FILE` | unset | Path to a file containing the secret key. |
+| `RUSTFS_RPC_SECRET` | derived | Secret used to authenticate internode RPC. When unset it is derived from the active access/secret key pair; with an all-default credential pair, multi-node clusters must set it explicitly. |
+
+:::warning
+The built-in default credentials `rustfsadmin`/`rustfsadmin` are for first-boot convenience only. Always set non-default credentials for production deployments.
+:::
+
+## Event & Audit targets
+
+Module switches:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTFS_NOTIFY_ENABLE` | `false` | Enable the bucket event notification module. |
+| `RUSTFS_AUDIT_ENABLE` | `false` | Enable the audit logging module. |
+
+Target configuration is pattern-based: `RUSTFS_NOTIFY_<TARGET>_<KEY>` for event notification and `RUSTFS_AUDIT_<TARGET>_<KEY>` for audit logs. Supported targets in both families: `WEBHOOK`, `KAFKA`, `MQTT`, `MYSQL`, `POSTGRES`, `NATS`, `REDIS`, `AMQP`, `PULSAR`.
+
+Sub-keys for the webhook target (the same keys exist under `RUSTFS_AUDIT_WEBHOOK_*`):
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTFS_NOTIFY_WEBHOOK_ENABLE` | `false` | Enable the webhook target. |
+| `RUSTFS_NOTIFY_WEBHOOK_ENDPOINT` | unset | Webhook HTTP(S) endpoint URL. |
+| `RUSTFS_NOTIFY_WEBHOOK_AUTH_TOKEN` | unset | Bearer token sent with each delivery. |
+| `RUSTFS_NOTIFY_WEBHOOK_QUEUE_DIR` | unset | Directory for the persistent delivery queue. |
+| `RUSTFS_NOTIFY_WEBHOOK_QUEUE_LIMIT` | unset | Maximum queued events. |
+| `RUSTFS_NOTIFY_WEBHOOK_CLIENT_CERT` | unset | Client certificate for mTLS to the endpoint. |
+| `RUSTFS_NOTIFY_WEBHOOK_CLIENT_KEY` | unset | Client private key for mTLS to the endpoint. |
+| `RUSTFS_NOTIFY_WEBHOOK_CLIENT_CA` | unset | CA certificate used to verify the endpoint. |
+| `RUSTFS_NOTIFY_WEBHOOK_SKIP_TLS_VERIFY` | unset | Skip TLS verification of the endpoint (not recommended). |
+
+Other targets follow the same shape with target-specific keys, e.g. `RUSTFS_NOTIFY_KAFKA_BROKERS`, `RUSTFS_NOTIFY_KAFKA_TOPIC`, `RUSTFS_NOTIFY_MQTT_BROKER`, `RUSTFS_NOTIFY_MQTT_TOPIC`, `RUSTFS_NOTIFY_MYSQL_DSN_STRING`, `RUSTFS_NOTIFY_NATS_ADDRESS`, `RUSTFS_NOTIFY_REDIS_URL`, `RUSTFS_NOTIFY_AMQP_URL`, `RUSTFS_NOTIFY_PULSAR_BROKER`.
+
+## Legacy compatibility
+
+### MINIO_* variable mapping
+
+For migration convenience, RustFS maps a fixed allowlist of `MINIO_*` variables to their `RUSTFS_*` equivalents at startup:
+
+- If only the `MINIO_`-prefixed variable is set, its value is used and a deprecation warning is logged.
+- If both `MINIO_*` and `RUSTFS_*` are set with different values, the `RUSTFS_*` value wins and a conflict is recorded.
+
+The mapped suffixes include `ACCESS_KEY`, `SECRET_KEY`, `ACCESS_KEY_FILE`, `SECRET_KEY_FILE`, `ROOT_USER`, `ROOT_PASSWORD`, `ADDRESS`, `CONSOLE_ADDRESS`, `VOLUMES`, `REGION`, `LICENSE`, `ERASURE_SET_DRIVE_COUNT`, `STORAGE_CLASS_STANDARD`, `STORAGE_CLASS_RRS`, `STORAGE_CLASS_OPTIMIZE`, `STORAGE_CLASS_INLINE_BLOCK`, `SCANNER_SPEED`, `SCANNER_CYCLE`, `COMPRESS_ENABLE`, `COMPRESS_EXTENSIONS`, `COMPRESS_MIME_TYPES`, `DRIVE_ACTIVE_MONITORING`, `ILM_EXPIRATION_WORKERS`, `API_XFF_HEADER`, `POLICY_PLUGIN_URL`, `POLICY_PLUGIN_AUTH_TOKEN`, the `IDENTITY_OPENID_*` keys, and every variable starting with `NOTIFY_WEBHOOK_`, `NOTIFY_MQTT_`, `AUDIT_WEBHOOK_`, or `AUDIT_MQTT_`. For example, `MINIO_ROOT_USER` maps to `RUSTFS_ROOT_USER` and `MINIO_NOTIFY_WEBHOOK_ENDPOINT` maps to `RUSTFS_NOTIFY_WEBHOOK_ENDPOINT`.
+
+### Deprecated aliases
+
+| Deprecated variable | Use instead |
+| --- | --- |
+| `RUSTFS_ROOT_USER` | `RUSTFS_ACCESS_KEY` |
+| `RUSTFS_ROOT_PASSWORD` | `RUSTFS_SECRET_KEY` |
+| `RUSTFS_DATA_SCANNER_START_DELAY_SECS` | `RUSTFS_SCANNER_START_DELAY_SECS` |
+
+Deprecated aliases still work but log a warning; the canonical `RUSTFS_*` name always takes precedence when both are set.

--- a/content/reference/metrics.md
+++ b/content/reference/metrics.md
@@ -1,0 +1,119 @@
+---
+title: "Metrics Reference"
+description: "This article lists the RustFS metric names, types, and labels that operators can chart and alert on after wiring the OTLP export pipeline into Prometheus."
+---
+
+## How to Read This Page
+
+RustFS exports metrics via OTLP push — there is no native `/metrics` scrape endpoint. Run an OpenTelemetry Collector with a Prometheus exporter and point `RUSTFS_OBS_ENDPOINT` at it; see [Monitoring and Alerting](../operations/monitoring) for the pipeline setup.
+
+Every name below is verified against the server source. The list covers the operations-relevant subset exported via OTLP; internal and experimental instruments are omitted, and new releases may add metrics not listed here. Label sets are those recorded at the emission site — the Collector and Prometheus may attach additional resource labels (`service_name`, instance, and so on).
+
+## Readiness and Process
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `rustfs_start_total` | counter | — | Process starts; a rising rate indicates restart loops |
+| `rustfs_runtime_readiness_ready` | gauge | — | `1` when the node is fully ready, `0` while degraded |
+| `rustfs_runtime_readiness_degraded_total` | counter | `reason` | Degraded readiness evaluations, by `degradedReasons` value (e.g. `storage_quorum_unavailable`) |
+
+## Scanner
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `rustfs_scanner_objects_scanned_total` | counter | — | Objects visited by the background scanner |
+| `rustfs_scanner_directories_scanned_total` | counter | — | Directories visited |
+| `rustfs_scanner_buckets_scanned_total` | counter | `result`, `bucket`, `disk` | Bucket/drive scans completed, by outcome (`success` / `error` / `partial`) |
+| `rustfs_scanner_cycles_total` | counter | `result` | Scanner cycles finished (`success` / `error` / `partial` / `unknown`) |
+| `rustfs_scanner_cycle_duration_seconds` | gauge | — | Duration of the last completed scan cycle |
+| `rustfs_scanner_bucket_drive_duration_seconds` | histogram | `bucket`, `disk` | Time to scan one bucket on one drive |
+| `rustfs_scanner_leader_lock_total` | counter | `state` | Scanner leader-lock acquisition events |
+| `rustfs_scanner_inline_heal_total` | counter | — | Objects queued for heal directly by the scanner |
+| `rustfs_scanner_cache_save_duration_seconds` | histogram | `cache` | Time to persist the data-usage cache |
+| `rustfs_scanner_set_scan_concurrency_limit` | gauge | — | Current per-set scan concurrency limit |
+| `rustfs_scanner_disk_scan_concurrency_limit` | gauge | `pool`, `set` | Current per-disk scan concurrency limit |
+
+## Heal
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `rustfs_heal_task_running` | gauge | `type`, `set` | Currently running heal tasks per erasure set |
+| `rustfs_heal_task_start_total` | counter | `type`, `set` | Heal tasks started |
+| `rustfs_heal_queue_delay_seconds` | histogram | `type`, `set` | Time a heal task waited in queue before starting |
+| `rustfs_heal_admission_total` | counter | `source`, `result`, `reason`, `context` | Heal admission decisions (accepted / rejected and why) |
+| `rustfs_heal_mainline_throttle_total` | counter | `source`, `result`, `reason` | Background heal throttled to protect foreground traffic |
+| `rustfs_heal_scheduler_skip_total` | counter | `reason`, `set` | Heal scheduling skipped (e.g. per-set limit reached) |
+| `rustfs_heal_page_concurrency_current` | gauge | — | Current page-level heal concurrency |
+| `rustfs_heal_candidate_enqueue_total` | counter | — | Heal candidates enqueued by the scanner |
+| `rustfs_heal_candidate_merge_total` | counter | — | Candidates merged with an existing queue entry |
+| `rustfs_heal_candidate_drop_total` | counter | — | Candidates dropped |
+| `rustfs_heal_candidate_priority_reject_total` | counter | — | Candidates rejected by priority policy |
+| `rustfs_heal_read_repair_dedup_total` | counter | `reason` | Read-path repair requests deduplicated |
+
+## API / IO Path
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `rustfs_io_get_object_request_duration_seconds` | histogram | `status` | End-to-end GetObject latency |
+| `rustfs_io_get_object_stage_duration_seconds` | histogram | `path`, `stage` | GetObject latency broken down by internal stage |
+| `rustfs_io_get_object_response_size_bytes` | histogram | — | GetObject response sizes |
+| `rustfs_io_operation_duration_seconds` | histogram | `operation` | Duration of IO operations |
+| `rustfs_io_timeout_events_total` | counter | `operation` | IO operations that hit a timeout |
+| `rustfs_operation_progress` | gauge | `operation` | Progress percentage of long-running operations |
+| `rustfs_operation_stalled` | counter | `operation` | Operations detected as stalled |
+| `rustfs_operation_completions` | counter | `operation`, `status` | Operation completions by status |
+| `rustfs_io_queue_operations` | counter | `operation`, `priority` | IO queue enqueue/dequeue operations |
+| `rustfs_io_queue_size` | gauge | `priority` | Current IO queue depth per priority |
+| `rustfs_io_starvation_events` | counter | `priority` | Low-priority IO starvation events |
+| `rustfs_io_bandwidth_bps` | gauge | — | Observed IO bandwidth (bytes/s) |
+| `rustfs_io_scheduler_decisions` | counter | — | IO scheduler decisions taken |
+| `rustfs_io_scheduler_load` | counter | `level` | Scheduler decisions by load level |
+| `rustfs_io_load_changes` | counter | `from`, `to` | IO load-level transitions |
+
+## Backpressure
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `rustfs_backpressure_state_changes` | counter | `from`, `to` | Backpressure state transitions |
+| `rustfs_backpressure_activations` | counter | — | Times backpressure engaged |
+| `rustfs_backpressure_deactivations` | counter | — | Times backpressure released |
+| `rustfs_backpressure_rejections` | counter | — | Requests rejected due to backpressure |
+| `rustfs_backpressure_concurrent` | gauge | — | Current concurrent requests tracked by the limiter |
+
+## Capacity
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `rustfs_capacity_current_bytes` | gauge | — | Current used capacity in bytes |
+| `rustfs_capacity_update_total` | counter | `source` | Capacity recalculations |
+| `rustfs_capacity_update_duration_seconds` | histogram | `source` | Time to recalculate capacity |
+| `rustfs_capacity_cache_hits` | counter | — | Capacity cache hits |
+| `rustfs_capacity_cache_misses` | counter | — | Capacity cache misses |
+| `rustfs_capacity_cache_served_total` | counter | `state` | Capacity responses served from cache, by freshness state |
+
+## Locking
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `rustfs_lock_contentions` | counter | — | Lock contention events |
+| `rustfs_lock_hold_time_secs` | histogram | — | How long locks were held |
+| `rustfs_lock_spin_successes` / `rustfs_lock_spin_failures` | counter | — | Spin-lock acquisition outcomes |
+| `rustfs_lock_early_releases` | counter | — | Locks released early by optimization |
+| `rustfs_object_lock_diag_acquire_duration_seconds` | histogram | — | Object-lock acquire latency (diagnostics mode) |
+| `rustfs_object_lock_diag_hold_duration_seconds` | histogram | — | Object-lock hold duration (diagnostics mode) |
+| `rustfs_object_lock_diag_slow_acquire_total` / `rustfs_object_lock_diag_slow_hold_total` | counter | — | Slow lock acquire/hold events (diagnostics mode) |
+
+## Log Cleaner
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `rustfs_log_cleaner_runs_total` | counter | — | Log-cleaner runs |
+| `rustfs_log_cleaner_deleted_files_total` | counter | — | Log files deleted |
+| `rustfs_log_cleaner_freed_bytes_total` | counter | — | Bytes reclaimed |
+| `rustfs_log_cleaner_rotation_total` / `rustfs_log_cleaner_rotation_failures_total` | counter | — | Log rotations and rotation failures |
+| `rustfs_log_cleaner_rotation_duration_seconds` | histogram | — | Rotation duration |
+| `rustfs_log_cleaner_active_file_size_bytes` | gauge | — | Size of the active log file |
+
+:::note
+Additional verified metric names exist whose type/label details are not documented here, including `rustfs_scanner_cache_save_attempt_total`, `rustfs_scanner_cache_save_timeout_total`, `rustfs_scanner_cache_save_retry_total`, `rustfs_scanner_excess_object_versions_total`, `rustfs_scanner_excess_object_version_size_total`, `rustfs_scanner_excess_folders_total`, `rustfs_scanner_pending_heal_prune_total`, `rustfs_scanner_pending_heal_malformed_total`, and the `rustfs_io_scheduler_*` / `rustfs_io_buffer_*` / `rustfs_timeout_dynamic_*` families. Inspect them in your Prometheus once the pipeline is live.
+:::

--- a/content/reference/ports.md
+++ b/content/reference/ports.md
@@ -1,0 +1,49 @@
+---
+title: "Ports and Health Endpoints"
+description: "Reference for the network ports RustFS listens on, the health check endpoints it exposes, and a minimal firewall configuration example."
+---
+
+RustFS uses two listeners. Both bind addresses are configurable; the values below are the defaults.
+
+## Port matrix
+
+| Port | Listener | Configured by | Traffic |
+| --- | --- | --- | --- |
+| `9000` | S3 API | `RUSTFS_ADDRESS` / `--address` | S3 object API, admin API, and internal node-to-node RPC (paths under `/rustfs/rpc/` and `/rustfs/peer/`) — all on the same port. |
+| `9001` | Console | `RUSTFS_CONSOLE_ADDRESS` / `--console-address` | Embedded web console (UI served under `/rustfs/console/`). Enabled by default; disable with `RUSTFS_CONSOLE_ENABLE=false`. |
+
+:::note
+Because internode RPC shares port 9000, every node in a multi-node cluster must be able to reach every other node on the S3 port. There is no separate cluster port to open.
+:::
+
+## Health endpoints
+
+Health probes are served unauthenticated on the S3 listener (port 9000) and can be disabled with `RUSTFS_HEALTH_ENDPOINT_ENABLE=false`:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /health` | Liveness probe (also accepts `HEAD`). `/health/live` is an alias. |
+| `GET /health/ready` | Readiness probe; reports whether storage is initialized and ready to serve. |
+| `GET /minio/health/live`, `/minio/health/ready`, `/minio/health/cluster`, `/minio/health/cluster/read` | MinIO-compatible probe aliases for existing tooling. |
+
+The console listener (port 9001) exposes its own probe at `GET /rustfs/console/health`.
+
+```bash title="Probe examples"
+curl -fsS http://localhost:9000/health
+curl -fsS http://localhost:9000/health/ready
+curl -fsS http://localhost:9001/rustfs/console/health
+```
+
+## Firewall example
+
+Open the S3 API and console ports with `firewalld`:
+
+```bash title="firewall-cmd"
+firewall-cmd --permanent --add-port=9000/tcp
+firewall-cmd --permanent --add-port=9001/tcp
+firewall-cmd --reload
+```
+
+:::warning
+Expose port 9001 (console) only to trusted networks. If the console is not needed, set `RUSTFS_CONSOLE_ENABLE=false` and do not open the port.
+:::


### PR DESCRIPTION
## Summary (review workstream: Reference section — rustfs/backlog#1272)

Adds four reference pages, every row verified against upstream source (unverifiable items were omitted and are listed in the review notes):

- **environment-variables** — 95 variables in 8 groups with defaults and sources; `MINIO_*` → `RUSTFS_*` compatibility mapping (60 entries) and deprecated aliases
- **cli** — `rustfs server/info/tls`, legacy invocation compatibility, 25 flag↔env↔default rows, `{N...M}` ellipses expansion and multi-pool syntax
- **ports** — 9000 (S3 + internal RPC on the same port) / 9001 (Console), `/health` and `/health/ready` probe endpoints, firewall example
- **metrics** — ~60 OTLP-exported metrics verified in source (scanner, heal, readiness, IO latency, capacity, locks)
- **s3-compatibility** — rewritten from marketing copy into the upstream quantified matrix (452 implemented / 17 unimplemented / 273 excluded), three-state tables by Bucket/Object/Multipart; no more "100% compatible" claims

Build: ✓ 375 pages.

---
Backed by the multi-role docs review (master issue rustfs/backlog#1277; six full reports ship in the nav PR under `docs-review/`). Technical facts verified against rustfs/rustfs@ea2e24ac.

## Rendered page previews (before / after)

<details><summary><code>/features/s3-compatibility</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/reference/features__s3-compatibility.png)

</details>
<details><summary><code>/reference/cli</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/reference/reference__cli.png)

</details>
<details><summary><code>/reference/environment-variables</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/reference/reference__environment-variables.png)

</details>
<details><summary><code>/reference/metrics</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/reference/reference__metrics.png)

</details>
<details><summary><code>/reference/ports</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/reference/reference__ports.png)

</details>
