### PR TITLE
docs: Kubernetes/Helm production guide and rolling-upgrade runbook

### DIFF
--- a/content/administration/iam/index.md
+++ b/content/administration/iam/index.md
@@ -1,12 +1,55 @@
 ---
 title: "RustFS IAM Management"
-description: "Comprehensive guide to Identity and Access Management (IAM), including Users, Groups, Policies, and Access Keys."
+description: "Overview of RustFS Identity and Access Management (IAM): identity types, policy attachment, and policy evaluation semantics."
 ---
 
-This section covers:
+RustFS ships a built-in Identity and Access Management (IAM) system modeled on the AWS IAM policy language. Every request — S3 data access, Console operation, or admin API call — is authenticated against a credential and then authorized against the policies attached to that identity.
 
-- User Management
-- User Group Management
-- Policy Management
-- Bucket Policy
-- Access Keys (AK/SK)
+## Identity Types
+
+RustFS distinguishes the following identity types:
+
+| Identity | Created by | Typical use |
+| --- | --- | --- |
+| Root credentials | `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` environment variables at server start | Initial setup and break-glass administration. The root account bypasses policy checks (owner semantics). |
+| IAM users | Console or admin API (`add-user`) | Long-term named accounts for people or applications. |
+| Groups | Console or admin API (`update-group-members`) | Attach one policy set to many users at once. Users inherit the policies of every group they belong to. |
+| Service accounts (access keys) | Console or admin API (`add-service-account`) | Derived credentials that belong to a parent user. They inherit the parent's permissions, optionally restricted further by an embedded session policy, and can carry an expiration time. |
+| STS temporary credentials | `AssumeRole` / `AssumeRoleWithWebIdentity` STS calls | Short-lived credentials (15 minutes to 12 hours) with an access key, secret key, and session token. |
+| External OIDC identities | OpenID Connect providers (Keycloak, Authing, and other standard OIDC IdPs) | Console SSO. ID token claims are mapped to RustFS policy names, and RustFS issues STS credentials. |
+
+:::warning
+
+Root credentials cannot be restricted by policies. Use them only to bootstrap the deployment, then create IAM users and service accounts for day-to-day work.
+
+:::
+
+## How Policies Attach to Identities
+
+Policies are named JSON documents stored in RustFS. Attachment works as follows:
+
+- **User binding** — one or more policy names are attached to an IAM user (`set-user-or-group-policy`, or the `idp/builtin/policy/attach` endpoint which accepts a list of policies).
+- **Group binding** — the same mechanism with `isGroup=true`; every member of the group receives the group's policies in addition to their own.
+- **Service accounts** — do not get their own policy bindings. They evaluate under the parent user's combined policies. If the service account was created with an explicit policy document, that session policy is applied as an additional restriction (both must allow).
+- **STS sessions** — inherit the parent identity's policies. The `Policy` request parameter of `AssumeRole` can embed an additional session policy that further restricts the temporary credentials.
+- **OIDC identities** — the ID token's `groups`/`roles` claim values are matched against RustFS policy names; the matched policies govern the issued STS credentials.
+
+RustFS ships these built-in (canned) policies: `readwrite`, `readonly`, `writeonly`, `diagnostics`, and `consoleAdmin`. See [Users, Groups, and Policies](./policies.md) for their contents and for writing custom policies.
+
+## Policy Evaluation Semantics
+
+When an identity has multiple attached policies, RustFS merges their statements (dropping duplicates) and evaluates the merged document:
+
+1. **Explicit deny wins.** All `Deny` statements are checked first; if any matching `Deny` statement applies to the request, the request is rejected regardless of any `Allow`.
+2. **Owner shortcut.** The root (owner) account is allowed once no explicit deny matched.
+3. **Explicit allow required.** Otherwise, at least one `Allow` statement must match the requested action and resource.
+4. **Default deny.** If no statement matches, the request is denied.
+
+For service accounts and STS sessions carrying a session policy, the effective permission is the intersection: the parent's policies and the session policy must both allow the request.
+
+## In This Section
+
+- [Users, Groups, and Policies](./policies.md) — managing users and groups, the policy document format, and built-in policies.
+- [Service Accounts and STS](./sts.md) — derived access keys and temporary credentials via `AssumeRole`.
+- [External Identity (OIDC)](./oidc.md) — Console SSO with Keycloak, Authing, or any standard OpenID Connect provider.
+- [Access Keys](./access-token.md) — creating and deleting access keys from the Console.

--- a/content/administration/iam/meta.json
+++ b/content/administration/iam/meta.json
@@ -1,6 +1,10 @@
 {
-  "title": "IAM Management",
+  "title": "IAM",
   "pages": [
-    "[Access Token](/administration/iam/access-token)"
+    "[Overview](/administration/iam)",
+    "[Users, Groups, and Policies](/administration/iam/policies)",
+    "[Service Accounts and STS](/administration/iam/sts)",
+    "[External Identity (OIDC)](/administration/iam/oidc)",
+    "[Access Keys](/administration/iam/access-token)"
   ]
 }

--- a/content/administration/iam/oidc.md
+++ b/content/administration/iam/oidc.md
@@ -1,0 +1,183 @@
+---
+title: "External Identity (OIDC)"
+description: "Connect the RustFS Console to Keycloak, Authing, or any standard OpenID Connect provider for single sign-on."
+---
+
+RustFS supports standard OpenID Connect (OIDC) for Console login. Any standards-compliant provider works; this guide uses Keycloak and Authing as worked examples. The examples use the default RustFS provider id, `default`.
+
+## Integration Model
+
+RustFS expects a provider that offers issuer metadata (`.well-known/openid-configuration`), an authorization endpoint, a token endpoint, a JWKS (or another verifiable ID token signature path), and an authorization-code flow that returns an `id_token`.
+
+The browser login flow is:
+
+1. The user opens the RustFS OIDC authorize endpoint (`/rustfs/admin/v3/oidc/authorize/<provider>`).
+2. RustFS creates `state`, `nonce`, and a PKCE S256 challenge, then redirects the browser to the provider.
+3. The provider redirects back to `/rustfs/admin/v3/oidc/callback/<provider>` with `code` and `state`.
+4. RustFS exchanges the code with `client_id`, `client_secret`, and the PKCE verifier.
+5. RustFS validates the ID token signature, issuer, audience, expiry, and nonce.
+6. RustFS maps ID token claim values to RustFS policy names and issues one-hour STS credentials for the Console.
+
+RustFS does not call the provider's authorization APIs for object or admin authorization. Authorization is handled entirely by RustFS policies after claims are mapped.
+
+## Claim Mapping
+
+RustFS reads `groups` or `roles` claims from the ID token and maps each value to a RustFS policy name. Keep claim values equal to policy names:
+
+| Claim value | RustFS policy | Purpose |
+| --- | --- | --- |
+| `consoleAdmin` | `consoleAdmin` | Full Console, admin, KMS, and S3 access. |
+| `readwrite` | `readwrite` | S3 read/write access. |
+| `readonly` | `readonly` | S3 read-only access. |
+| `writeonly` | `writeonly` | S3 write-only access. |
+| `diagnostics` | `diagnostics` | Diagnostic admin access. |
+
+If a login succeeds but no claim value matches a RustFS policy (and no group is mapped), the STS exchange is rejected.
+
+## RustFS Configuration
+
+Configure the provider and the public browser origin through environment variables, then restart RustFS:
+
+```bash
+export RUSTFS_BROWSER_REDIRECT_URL="https://rustfs.example.com"
+
+export RUSTFS_IDENTITY_OPENID_ENABLE=on
+export RUSTFS_IDENTITY_OPENID_CONFIG_URL="<ISSUER_URL>"
+export RUSTFS_IDENTITY_OPENID_CLIENT_ID="<CLIENT_ID>"
+export RUSTFS_IDENTITY_OPENID_CLIENT_SECRET="<CLIENT_SECRET>"
+export RUSTFS_IDENTITY_OPENID_SCOPES="openid,profile,email"
+export RUSTFS_IDENTITY_OPENID_REDIRECT_URI="https://rustfs.example.com/rustfs/admin/v3/oidc/callback/default"
+export RUSTFS_IDENTITY_OPENID_REDIRECT_URI_DYNAMIC=off
+export RUSTFS_IDENTITY_OPENID_DISPLAY_NAME="My IdP"
+export RUSTFS_IDENTITY_OPENID_GROUPS_CLAIM="groups"
+export RUSTFS_IDENTITY_OPENID_ROLES_CLAIM="roles"
+export RUSTFS_IDENTITY_OPENID_EMAIL_CLAIM="email"
+export RUSTFS_IDENTITY_OPENID_USERNAME_CLAIM="preferred_username"
+```
+
+For short-lived connectivity testing only, you may temporarily add:
+
+```bash
+export RUSTFS_IDENTITY_OPENID_ROLE_POLICY="consoleAdmin"
+```
+
+:::warning
+
+Do not keep `role_policy=consoleAdmin` in production unless every user of this client should receive full Console access. Claim-to-policy mapping is the production authorization model.
+
+:::
+
+If the deployment manages configuration through compatible admin commands, the same keys can be set with `mc admin config set <alias> identity_openid enable=on config_url=... client_id=... client_secret=... scopes=... redirect_uri=... redirect_uri_dynamic=off display_name=... groups_claim=... roles_claim=... email_claim=... username_claim=...` followed by `mc admin service restart <alias>`.
+
+:::note
+
+`RUSTFS_BROWSER_REDIRECT_URL` is a process environment variable, not an `identity_openid` provider key. Configure it in the RustFS service environment even when the provider is stored through admin config.
+
+:::
+
+### Named Providers
+
+To register more than one provider (or use a provider id other than `default`), suffix the provider-specific environment variables with the provider id and register the matching callback URL at the IdP:
+
+```bash
+export RUSTFS_IDENTITY_OPENID_ENABLE_keycloak=on
+export RUSTFS_IDENTITY_OPENID_CONFIG_URL_keycloak="https://keycloak.example.com/realms/rustfs"
+export RUSTFS_IDENTITY_OPENID_CLIENT_ID_keycloak="rustfs-console"
+export RUSTFS_IDENTITY_OPENID_CLIENT_SECRET_keycloak="<KEYCLOAK_CLIENT_SECRET>"
+export RUSTFS_IDENTITY_OPENID_SCOPES_keycloak="openid,profile,email"
+export RUSTFS_IDENTITY_OPENID_REDIRECT_URI_keycloak="https://rustfs.example.com/rustfs/admin/v3/oidc/callback/keycloak"
+export RUSTFS_IDENTITY_OPENID_REDIRECT_URI_DYNAMIC_keycloak=off
+export RUSTFS_IDENTITY_OPENID_DISPLAY_NAME_keycloak="Keycloak"
+export RUSTFS_IDENTITY_OPENID_GROUPS_CLAIM_keycloak="groups"
+```
+
+`RUSTFS_BROWSER_REDIRECT_URL` remains global and is not suffixed per provider.
+
+### Redirect URL Priority
+
+RustFS builds browser-facing URLs with this priority:
+
+1. Provider `redirect_uri`, when configured, is used for the OIDC callback URL sent to the IdP.
+2. `RUSTFS_BROWSER_REDIRECT_URL`, when configured, is used as the public origin for OIDC callback generation when no provider `redirect_uri` exists, and for Console success redirects and logout fallback redirects.
+3. Request headers are used only when provider dynamic redirects are enabled and no browser redirect URL is configured.
+
+For reverse-proxy or load-balancer deployments, set `RUSTFS_BROWSER_REDIRECT_URL` to avoid depending on `Host` and `X-Forwarded-Proto`. OIDC authorize and callback requests must reach the same RustFS node, because in-flight OIDC `state` is local to the node — configure session affinity on the load balancer.
+
+## Example: Keycloak
+
+Example values: realm `rustfs`, issuer `https://keycloak.example.com/realms/rustfs`, client id `rustfs-console`, callback `https://rustfs.example.com/rustfs/admin/v3/oidc/callback/default`.
+
+1. Create or select the `rustfs` realm and verify discovery:
+
+   ```bash
+   curl -fsS "https://keycloak.example.com/realms/rustfs/.well-known/openid-configuration" \
+     | jq '.issuer,.authorization_endpoint,.token_endpoint,.jwks_uri'
+   ```
+
+2. Create a client: `Client type` = `OpenID Connect`, `Client ID` = `rustfs-console`, enable `Client authentication` and `Standard flow`, disable `Implicit flow`, `Direct access grants`, and `Service accounts roles`. Set `Valid redirect URIs` to the exact RustFS callback URL, `Web origins` to `https://rustfs.example.com`, and PKCE Code Challenge Method to `S256`. Copy the client secret from `Credentials`.
+3. Map groups to policies: create Keycloak groups named after RustFS policies (e.g. `consoleAdmin`, `readonly`), add users, and add a `Group Membership` mapper to the client scope with `Token Claim Name` = `groups`, `Full group path` = `Off`, `Add to ID token` = `On`, `Multivalued` = `On`.
+4. Configure RustFS with `RUSTFS_IDENTITY_OPENID_CONFIG_URL="https://keycloak.example.com/realms/rustfs"` and the client id/secret as shown above, then restart.
+
+:::note
+
+Keep `Full group path` disabled. RustFS policy names cannot contain `/`, so `/consoleAdmin` will not map to the `consoleAdmin` policy. If you use Keycloak roles instead of groups, emit a flat top-level `roles` claim (via a `User Realm Role` or `User Client Role` mapper) and set `RUSTFS_IDENTITY_OPENID_ROLES_CLAIM=roles` — RustFS does not parse Keycloak's nested `realm_access.roles` claim. RustFS submits the client secret in the token request body, so do not disable `client_secret_post`.
+
+:::
+
+## Example: Authing
+
+Example values: application domain `https://example.authing.cn`, issuer `https://example.authing.cn/oidc`, App ID as `client_id`, App Secret as `client_secret`.
+
+1. Create a self-hosted application named `RustFS Console`; record the App ID, App Secret, issuer, and discovery URL. Authing deployments use different issuer paths (`/oidc` or `/oauth/oidc`) — always copy the issuer from the Authing console.
+2. Protocol settings: Protocol = OpenID Connect, Grant type = Authorization Code, Response type = `code`, token endpoint authentication = `client_secret_post`, PKCE = allow or require `S256`, ID token signing algorithm = `RS256` recommended.
+3. Register the exact callback URL `https://rustfs.example.com/rustfs/admin/v3/oidc/callback/default`.
+4. Assign users roles named after RustFS policies and confirm the ID token contains, for example:
+
+   ```json
+   {
+     "roles": ["consoleAdmin"]
+   }
+   ```
+
+5. Configure RustFS with `RUSTFS_IDENTITY_OPENID_SCOPES="openid,profile,email,roles"` and `RUSTFS_IDENTITY_OPENID_ROLES_CLAIM="roles"`, then restart.
+
+## Validation
+
+Verify provider discovery, then check that the provider is visible to RustFS:
+
+```bash
+curl -fsS "https://rustfs.example.com/rustfs/admin/v3/oidc/providers" | jq
+```
+
+Test the browser flow by opening:
+
+```text
+https://rustfs.example.com/rustfs/admin/v3/oidc/authorize/default
+```
+
+Expected result: redirect to the IdP, sign in, redirect back to `/rustfs/admin/v3/oidc/callback/default?code=...&state=...`, RustFS validates the ID token, issues STS credentials, and the browser lands on the Console with the mapped permissions.
+
+## Troubleshooting
+
+| Symptom | Common cause | Fix |
+| --- | --- | --- |
+| `/oidc/providers` does not show the provider | Provider did not load, or RustFS was not restarted | Check environment variables and restart RustFS. |
+| IdP reports a redirect mismatch | Registered redirect URI differs from the RustFS callback URL | Use the exact callback URL including the provider id. |
+| Callback reports missing `code` or `state` | Proxy dropped the query string | Preserve the full callback URL and query string. |
+| Token exchange fails | Wrong client secret or token auth method | Confirm the client is confidential and accepts `client_secret_post`. |
+| RustFS reports no `id_token` | Missing `openid` scope or non-OIDC flow | Include `openid` and use the authorization code flow. |
+| ID token verification fails | Issuer, audience, signing algorithm, or JWKS mismatch | Compare discovery metadata with the RustFS config; prefer `RS256`. |
+| Login succeeds but access is denied | No claim value matched a RustFS policy | Emit `groups` or `roles` as a flat ID token claim matching policy names. |
+| Console redirects to an internal host | Missing `RUSTFS_BROWSER_REDIRECT_URL` | Set it to the public browser origin. |
+| Invalid or expired OIDC state | Callback reached a different RustFS node | Configure load-balancer session affinity for authorize and callback. |
+
+## Production Checklist
+
+- The IdP and RustFS use HTTPS.
+- The registered redirect URI is the exact callback URL, not a wildcard.
+- `RUSTFS_BROWSER_REDIRECT_URL` is set to the public RustFS browser origin.
+- `RUSTFS_IDENTITY_OPENID_REDIRECT_URI` matches the registered callback URL.
+- PKCE S256 is enabled or required.
+- Users receive `groups` or `roles` claims that match RustFS policy names.
+- `role_policy=consoleAdmin` is not used as a permanent production shortcut.
+- The load balancer preserves query strings and pins authorize/callback requests to one node.

--- a/content/administration/iam/policies.md
+++ b/content/administration/iam/policies.md
@@ -1,0 +1,179 @@
+---
+title: "Users, Groups, and Policies"
+description: "Managing RustFS IAM users and groups, the policy document JSON format, condition operators, and built-in policies."
+---
+
+This page covers day-to-day IAM administration: creating users and groups, attaching policies, and writing custom policy documents.
+
+## Managing Users
+
+Users can be managed from the Console (**Identity** section in the left navigation) or through the admin REST API. All admin endpoints live under the `/rustfs/admin/v3` prefix; a MinIO-compatible prefix (`/minio/admin`) is also served for `mc admin` / madmin-style clients. Requests must be signed (AWS Signature V4) by a credential whose policies allow the corresponding `admin:*` action.
+
+| Operation | Method and path | Notes |
+| --- | --- | --- |
+| Create/update user | `PUT /rustfs/admin/v3/add-user?accessKey=<name>` | JSON body: `{"secretKey": "...", "status": "enabled"}`; `policy` is optional. Requires `admin:CreateUser`. |
+| List users | `GET /rustfs/admin/v3/list-users` | Requires `admin:ListUsers`. |
+| User details | `GET /rustfs/admin/v3/user-info?accessKey=<name>` | Requires `admin:GetUser`. |
+| Enable/disable user | `PUT /rustfs/admin/v3/set-user-status?accessKey=<name>&status=<enabled\|disabled>` | You cannot change the status of the credential making the call. |
+| Delete user | `DELETE /rustfs/admin/v3/remove-user?accessKey=<name>` | Requires `admin:DeleteUser`. |
+| Export IAM data | `GET /rustfs/admin/v3/export-iam` | Dumps users, groups, policies, and mappings. |
+| Import IAM data | `PUT /rustfs/admin/v3/import-iam` | Restores an exported dataset. |
+
+:::note
+
+A user name (access key) must not contain spaces and cannot equal the root access key. The secret key is required when creating a user.
+
+:::
+
+## Managing Groups
+
+Groups collect users so a single policy binding covers all members. Group membership and status are managed with these endpoints (Console equivalents exist under **Identity**):
+
+| Operation | Method and path | Notes |
+| --- | --- | --- |
+| List groups | `GET /rustfs/admin/v3/groups` | Requires `admin:ListGroups`. |
+| Group details | `GET /rustfs/admin/v3/group?group=<name>` | Requires `admin:GetGroup`. |
+| Add/remove members | `PUT /rustfs/admin/v3/update-group-members` | JSON body below. Adding members to a nonexistent group creates it. Requires `admin:AddUserToGroup` / `admin:RemoveUserFromGroup`. |
+| Enable/disable group | `PUT /rustfs/admin/v3/set-group-status?group=<name>&status=<enabled\|disabled>` | Requires `admin:EnableGroup` / `admin:DisableGroup`. |
+| Delete group | `DELETE /rustfs/admin/v3/group/{group}` | Fails while the group still has members. |
+
+Membership update body:
+
+```json
+{
+  "group": "developers",
+  "members": ["alice", "bob"],
+  "isRemove": false
+}
+```
+
+Set `isRemove` to `true` to remove the listed members instead. Temporary (STS) users and the root credential cannot be added to groups.
+
+## Attaching Policies
+
+Policy bindings connect a named policy to a user or a group:
+
+| Operation | Method and path | Notes |
+| --- | --- | --- |
+| Set policy for user or group | `PUT /rustfs/admin/v3/set-user-or-group-policy?policyName=<policy>&userOrGroup=<name>&isGroup=<true\|false>` | Replaces the binding. Also served as `/rustfs/admin/v3/set-policy`. Requires `admin:AttachUserOrGroupPolicy`. |
+| Attach policies | `POST /rustfs/admin/v3/idp/builtin/policy/attach` | JSON body: `{"policies": ["readonly"], "user": "alice"}` (or `"group"`). Adds to the existing binding. |
+| Detach policies | `POST /rustfs/admin/v3/idp/builtin/policy/detach` | Same body shape; removes policies from the binding. |
+| List policy bindings | `GET /rustfs/admin/v3/idp/builtin/policy-entities` | Shows which users/groups have which policies. |
+
+## Managing Policy Documents
+
+| Operation | Method and path | Notes |
+| --- | --- | --- |
+| List policies | `GET /rustfs/admin/v3/list-canned-policies` | Requires `admin:GetPolicy` scope for details. |
+| Policy details | `GET /rustfs/admin/v3/info-canned-policy?name=<policy>` | Returns the JSON document. |
+| Create/replace policy | `PUT /rustfs/admin/v3/add-canned-policy?name=<policy>` | Request body is the policy JSON document. Requires `admin:CreatePolicy`. |
+| Delete policy | `DELETE /rustfs/admin/v3/remove-canned-policy?name=<policy>` | Requires `admin:DeletePolicy`. |
+
+## Policy Document Format
+
+A policy document is a JSON object with `Version` and `Statement` fields. The only accepted `Version` value is `2012-10-17`.
+
+Each statement supports:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `Sid` | No | Statement identifier. |
+| `Effect` | Yes | `Allow` or `Deny`. |
+| `Action` | Yes (or `NotAction`) | Action names, wildcards allowed (e.g. `s3:Get*`). |
+| `NotAction` | No | Matches every action except the listed ones. |
+| `Resource` | Yes for S3 actions (or `NotResource`) | ARNs in the form `arn:aws:s3:::bucket` or `arn:aws:s3:::bucket/prefix/*`. |
+| `NotResource` | No | Matches every resource except the listed ones. |
+| `Condition` | No | Condition operators keyed by context values. |
+
+Action names are namespaced: `s3:*` for object/bucket operations (e.g. `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:ListBucket`, `s3:GetBucketLocation`, `s3:ListAllMyBuckets`), `admin:*` for management operations, `sts:AssumeRole` for STS, and `kms:*` for key management.
+
+Supported condition operators include: `StringEquals`, `StringNotEquals`, `StringEqualsIgnoreCase`, `StringNotEqualsIgnoreCase`, `StringLike`, `StringNotLike`, `ArnEquals`, `ArnNotEquals`, `ArnLike`, `ArnNotLike`, `BinaryEquals`, `IpAddress`, `NotIpAddress`, `Null`, `Bool`, `NumericEquals`, `NumericNotEquals`, `NumericLessThan`, `NumericLessThanEquals`, `NumericGreaterThan`, `NumericGreaterThanEquals`, `DateEquals`, `DateNotEquals`, `DateLessThan`, `DateLessThanEquals`, `DateGreaterThan`, and `DateGreaterThanEquals`. Any operator can be suffixed with `IfExists` (the condition passes when the referenced context key is absent).
+
+### Example: Read-Only Access to One Bucket
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetBucketLocation", "s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::reports"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": ["arn:aws:s3:::reports/*"]
+    }
+  ]
+}
+```
+
+### Example: Read/Write Restricted to a Prefix
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::app-data"],
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": ["tenant-42/*"]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": ["arn:aws:s3:::app-data/tenant-42/*"]
+    }
+  ]
+}
+```
+
+### Example: Full Access but Deletion Denied
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:*"],
+      "Resource": ["arn:aws:s3:::archive", "arn:aws:s3:::archive/*"]
+    },
+    {
+      "Effect": "Deny",
+      "Action": ["s3:DeleteObject", "s3:DeleteObjectVersion", "s3:DeleteBucket"],
+      "Resource": ["arn:aws:s3:::archive", "arn:aws:s3:::archive/*"]
+    }
+  ]
+}
+```
+
+:::note
+
+An explicit `Deny` always overrides `Allow`, so the second statement wins for delete operations even though `s3:*` matches them. See the [evaluation semantics](./index.md#policy-evaluation-semantics).
+
+:::
+
+## Built-In Policies
+
+RustFS defines five built-in policies that can be attached without creating them first:
+
+| Policy | Grants |
+| --- | --- |
+| `readwrite` | All S3 actions (`s3:*`) on all resources, plus `sts:AssumeRole`. |
+| `readonly` | `s3:GetBucketLocation`, `s3:GetObject`, and `s3:GetBucketQuota` on all resources, plus `sts:AssumeRole`. |
+| `writeonly` | `s3:PutObject` on all resources, plus `sts:AssumeRole`. |
+| `diagnostics` | Diagnostic admin actions (`admin:Profiling`, `admin:ServerTrace`, `admin:ConsoleLog`, `admin:ServerInfo`, `admin:TopLocksInfo`, `admin:OBDInfo`, `admin:Prometheus`, `admin:BandwidthMonitor`), plus `sts:AssumeRole`. |
+| `consoleAdmin` | All admin actions (`admin:*`), all KMS actions (`kms:*`), all S3 actions (`s3:*`), plus `sts:AssumeRole`. |
+
+:::warning
+
+The built-in `readonly` policy is intentionally minimal — it does not include `s3:ListBucket` or `s3:ListAllMyBuckets`. Users with only `readonly` can fetch objects by key but cannot browse buckets. Create a custom policy if listing is needed.
+
+:::

--- a/content/administration/iam/sts.md
+++ b/content/administration/iam/sts.md
@@ -1,0 +1,105 @@
+---
+title: "Service Accounts and STS"
+description: "RustFS service accounts (derived access keys) and temporary credentials via the STS AssumeRole API."
+---
+
+RustFS provides two mechanisms for issuing credentials that are derived from an existing identity: **service accounts** (long-lived access keys owned by a parent user) and **STS temporary credentials** (short-lived keys with a session token).
+
+## Service Accounts
+
+A service account is an access key/secret key pair that belongs to a parent IAM user (or to the root account). It authenticates like a normal key but is authorized as its parent:
+
+- **Inherited policy (default).** If the service account is created without a policy, it inherits whatever the parent user's combined policies allow at request time.
+- **Session-bound policy.** If a policy document is supplied at creation, it is embedded into the service account. Requests must then be allowed by *both* the parent's policies and the embedded policy.
+- **Expiration.** An optional expiration timestamp (RFC 3339) can be set; the credential stops working after that time.
+
+Service accounts cannot call `AssumeRole`, and a service account access key cannot be turned into a regular IAM user.
+
+In the Console, service accounts are managed on the **Access Keys** page — see [Access Key Management](./access-token.md). The admin API exposes:
+
+| Operation | Method and path | Notes |
+| --- | --- | --- |
+| Create service account | `PUT /rustfs/admin/v3/add-service-account` | Body below. Also served at `/add-service-accounts`. Requires `admin:CreateServiceAccount` when creating for another user (`targetUser`). |
+| List service accounts | `GET /rustfs/admin/v3/list-service-accounts?user=<name>` | Requires `admin:ListServiceAccounts` to list another user's accounts. |
+| List access keys (bulk) | `GET /rustfs/admin/v3/list-access-keys-bulk` | Supports filtering to users only, service accounts only, or STS keys only. |
+| Service account details | `GET /rustfs/admin/v3/info-service-account?accessKey=<key>` | Returns name, description, parent, expiration, and the session policy (or `impliedPolicy: true` when inherited). |
+| Temporary account details | `GET /rustfs/admin/v3/temporary-account-info?accessKey=<key>` | For STS-issued keys. |
+| Access key details | `GET /rustfs/admin/v3/info-access-key?accessKey=<key>` | Unified lookup across users, service accounts, and STS keys. |
+| Update service account | `POST /rustfs/admin/v3/update-service-account?accessKey=<key>` | Can rotate the secret, change status, name, description, expiration, or replace the policy. |
+| Delete service account | `DELETE /rustfs/admin/v3/delete-service-account?accessKey=<key>` | Also served at `/delete-service-accounts`. Non-admin callers can delete only their own service accounts. |
+
+Creation body (all fields optional unless noted):
+
+```json
+{
+  "policy": { "Version": "2012-10-17", "Statement": [] },
+  "targetUser": "alice",
+  "accessKey": "myserviceaccount",
+  "secretKey": "mysecret",
+  "name": "ci-pipeline",
+  "description": "Key used by CI",
+  "expiration": "2027-01-01T00:00:00Z"
+}
+```
+
+:::note
+
+Omit `accessKey`/`secretKey` to have RustFS generate a random pair. Omit `policy` to create an inherited-policy service account. `targetUser` requires admin privileges; regular users create service accounts for themselves.
+
+:::
+
+## STS Temporary Credentials
+
+RustFS implements an AWS-compatible STS endpoint at the server root (`POST /` with form-encoded parameters). Two actions are supported:
+
+- `AssumeRole` — for existing IAM identities, signed with SigV4.
+- `AssumeRoleWithWebIdentity` — for OIDC identities, authenticated by the JWT itself (see [External Identity (OIDC)](./oidc.md)).
+
+### AssumeRole
+
+The request must be signed (AWS Signature V4) by a long-term IAM credential — temporary credentials and service accounts cannot call `AssumeRole`. The calling identity also needs the `sts:AssumeRole` action allowed by its policies (all built-in policies include it).
+
+Form parameters:
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `Action` | Yes | `AssumeRole`. |
+| `Version` | Yes | Must be `2011-06-15`. |
+| `DurationSeconds` | No | Credential lifetime in seconds. Default 3600 (1 hour); values are clamped to the range 900 (15 minutes) to 43200 (12 hours). |
+| `Policy` | No | An inline session policy (JSON) that further restricts the temporary credentials. |
+| `RoleArn`, `RoleSessionName`, `ExternalId` | No | Accepted for AWS compatibility. |
+
+Example:
+
+```bash
+curl -s -X POST "https://rustfs.example.com/" \
+  --user "$ACCESS_KEY:$SECRET_KEY" \
+  --aws-sigv4 "aws:amz:us-east-1:s3" \
+  -d "Action=AssumeRole" \
+  -d "Version=2011-06-15" \
+  -d "DurationSeconds=3600"
+```
+
+The response is an XML `AssumeRoleResponse` containing `AccessKeyId`, `SecretAccessKey`, `SessionToken`, and `Expiration`. Use all three values on subsequent S3 requests (the session token goes in `X-Amz-Security-Token`).
+
+The temporary credential inherits the caller's policies; the `parent` of the credential is the calling access key. If a `Policy` parameter was supplied, it is stored in the session and applied as an additional restriction.
+
+### AssumeRoleWithWebIdentity
+
+Used by the OIDC flow; no SigV4 signature is needed because the identity provider's JWT is the authentication:
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `Action` | Yes | `AssumeRoleWithWebIdentity`. |
+| `Version` | Yes | Must be `2011-06-15`. |
+| `WebIdentityToken` | Yes | The OIDC ID token issued by a configured provider. |
+| `DurationSeconds` | No | Same default and 900–43200 clamping as `AssumeRole`. |
+| `Policy` | No | Optional inline session policy. |
+
+RustFS verifies the token against the configured provider (signature, issuer, audience, expiry), maps its `groups`/`roles` claims to RustFS policy names, and rejects the request if no policies or groups can be mapped. The response is an XML `AssumeRoleWithWebIdentityResponse` with the same credential fields plus `SubjectFromWebIdentityToken`.
+
+:::warning
+
+Keep `DurationSeconds` as short as your workload allows; a leaked temporary credential remains valid until its expiration.
+
+:::

--- a/content/installation/cloud-native/index.md
+++ b/content/installation/cloud-native/index.md
@@ -1,7 +1,200 @@
 ---
-title: "English Documentation"
-description: "This documentation is being translated from Chinese to English"
+title: "Kubernetes Installation (Helm)"
+description: "Deploy RustFS on Kubernetes with the official Helm chart: standalone or distributed mode, storage sizing, probes, production hardening, and server-pool expansion."
 ---
 
-This section contains the RustFS documentation translated into English.
+RustFS ships an official Helm chart that deploys either a single-node instance (a `Deployment` with one PVC) or a distributed cluster (a `StatefulSet` with multiple pods and PVCs). This guide walks through installing the chart, choosing a deployment mode, sizing storage correctly, and the production options the chart provides.
 
+**Prerequisites**
+
+- A Kubernetes cluster and `kubectl` access
+- Helm 3
+- RustFS image version `>= 1.0.0-alpha.69` (the chart requirement)
+- A StorageClass with a working provisioner — the chart defaults to [`local-path`](https://github.com/rancher/local-path-provisioner); set `storageclass.name` to use your own
+
+The chart lives in the RustFS source repository under `helm/rustfs`:
+
+```bash
+git clone https://github.com/rustfs/rustfs.git
+cd rustfs/helm/rustfs
+```
+
+## 1. Quick install
+
+Install into a dedicated namespace, setting your own credentials and a realistic data size:
+
+```bash
+helm install rustfs . \
+  --namespace rustfs --create-namespace \
+  --set secret.rustfs.access_key=<your-access-key> \
+  --set secret.rustfs.secret_key=<your-secret-key> \
+  --set storageclass.dataStorageSize=100Gi \
+  --set storageclass.logStorageSize=1Gi
+```
+
+:::note[The chart refuses default credentials]
+
+Rendering fails by default unless one of the following is true:
+
+1. `secret.existingSecret` names a Kubernetes Secret you control, or
+2. `secret.rustfs.access_key` and `secret.rustfs.secret_key` are **both** set to non-empty, non-default values, or
+3. `secret.allowInsecureDefaults: true` is set (only for local development).
+
+This prevents accidental deployment with the well-known default `rustfsadmin`/`rustfsadmin` credentials. Setting only one of the two keys is also rejected, so the chart never silently falls back to a default for the missing key.
+
+:::
+
+Watch the pods come up:
+
+```bash
+kubectl -n rustfs get pods -w
+```
+
+```text
+NAME       READY   STATUS    RESTARTS   AGE
+rustfs-0   1/1     Running   0          2m27s
+rustfs-1   1/1     Running   0          2m27s
+rustfs-2   1/1     Running   0          2m27s
+rustfs-3   1/1     Running   0          2m27s
+```
+
+## 2. Choose a deployment mode
+
+The chart supports two modes, selected via the `mode` values:
+
+| Mode | Values | Workload | Layout |
+| --- | --- | --- | --- |
+| Distributed (**default**) | `mode.distributed.enabled=true` | StatefulSet | `replicaCount: 4` pods, 4 data PVCs each (16 drives total) — or `replicaCount: 16` for 16 pods with 1 data PVC each |
+| Standalone | `mode.standalone.enabled=true`, `mode.distributed.enabled=false` | Deployment | 1 pod, 1 data PVC (single node single disk) |
+
+- **Standalone** matches single-node single-disk: no erasure-coding redundancy across nodes. Use it for development, testing, or small setups where the underlying storage provides its own durability. It can reuse existing PVCs via `mode.standalone.existingClaim.dataClaim` / `mode.standalone.existingClaim.logsClaim`.
+- **Distributed** behaves like [multiple node multiple disk](../linux/multiple-node-multiple-disk.md): objects are erasure-coded across pods and PVCs. `replicaCount` must be `4` (each pod gets 4 PVCs) or `16` (each pod gets 1 PVC); pick based on how many nodes your cluster can spread pods across.
+
+```bash
+# Standalone mode
+helm install rustfs . -n rustfs --create-namespace \
+  --set mode.standalone.enabled=true \
+  --set mode.distributed.enabled=false \
+  --set secret.rustfs.access_key=<your-access-key> \
+  --set secret.rustfs.secret_key=<your-secret-key>
+```
+
+## 3. Storage sizing
+
+PVC sizes come from the `storageclass` block:
+
+```yaml title="values-prod.yaml"
+storageclass:
+  name: local-path        # your StorageClass
+  dataStorageSize: 256Mi  # per data PVC
+  logStorageSize: 256Mi   # per logs PVC
+```
+
+:::warning[The default PVC size is 256Mi — change it]
+
+The chart's default size for the data and logs volumes is **256Mi**, which is only enough to verify the chart works. For any real workload set `storageclass.dataStorageSize` (for example `1Ti`) and `storageclass.logStorageSize` (for example `1Gi`) at install time. In distributed mode the data size applies to **each** data PVC (16 PVCs by default).
+
+:::
+
+Setting `config.rustfs.obs_log_directory` to `""` disables the log PVCs and mounts entirely. Custom PVC annotations go under `storageclass.pvcAnnotations.data` / `storageclass.pvcAnnotations.logs`.
+
+## 4. Health probes
+
+The chart templates HTTP probes on the S3 port (9000) out of the box, matching the server's health endpoints:
+
+- **Liveness**: `GET /health` (`livenessProbe.httpGet.path`), initial delay 30s, period 5s
+- **Readiness**: `GET /health/ready` (`readinessProbe.httpGet.path`), initial delay 10s, period 5s
+
+A pod is only added to the Service endpoints once `/health/ready` returns `200`, which in distributed mode requires the storage quorum to be met. Thresholds and timings are tunable via the `livenessProbe.*` and `readinessProbe.*` values.
+
+## 5. Production hardening
+
+### Pod Disruption Budget
+
+Disabled by default. Enable it so voluntary evictions (node drains, cluster upgrades) never take more than one pod down at a time:
+
+```bash
+--set pdb.create=true    # pdb.maxUnavailable defaults to 1
+```
+
+### Anti-affinity and topology spread
+
+`affinity.podAntiAffinity.enabled` defaults to `true` with `topologyKey: kubernetes.io/hostname`, spreading pods across distinct nodes. For zone-level spreading, enable `topologySpreadConstraints.enabled` and supply raw constraint entries under `topologySpreadConstraints.constraints` (applied to the distributed StatefulSet).
+
+### Inter-pod mTLS (cert-manager)
+
+Set `mtls.enabled=true` to encrypt traffic between pods; the chart renders cert-manager `Issuer`/`Certificate` resources for a CA, server, and client certificates. To use an issuer you already operate, set `mtls.existingIssuerRef.enabled=true` with its `name`, `kind` (`Issuer` or `ClusterIssuer`), and `group`.
+
+### Ingress and Gateway API
+
+Ingress is enabled by default (`ingress.enabled=true`) with `ingress.className: nginx`; set it to `traefik` if that is your controller — the chart applies the matching session-stickiness annotations for each. Set your domain via `ingress.hosts[0].host` (default `example.rustfs.com`). For HTTPS, enable `ingress.tls.enabled` and either pass the certificate with `--set-file ingress.tls.crt=./tls.crt --set-file ingress.tls.key=./tls.key`, point at an existing secret (`ingress.tls.existingSecret`), or let cert-manager issue one (`ingress.tls.certManager.enabled=true`).
+
+The chart also has alpha [Gateway API](https://gateway-api.sigs.k8s.io/) support (`gatewayApi.enabled=true` together with `ingress.enabled=false`, Traefik gateway class), rendering `Gateway` and `HTTPRoute` resources.
+
+## 6. Access RustFS
+
+Without an ingress, port-forward the Service:
+
+```bash
+kubectl -n rustfs port-forward svc/rustfs 9000:9000 9001:9001
+```
+
+- S3 API: `http://localhost:9000`
+- Console: `http://localhost:9001`
+
+Log in to the Console with the access key and secret key you set at install time. With ingress enabled, use your configured host instead (check `kubectl -n rustfs get ing`). The Service defaults to `ClusterIP`; `service.type` can be switched to `NodePort` (S3 on `service.endpoint.nodePort: 32000`, Console on `service.console.nodePort: 32001`) or `LoadBalancer`.
+
+## 7. Scaling out with server pools
+
+In distributed mode the chart can run multiple **server pools** — independent StatefulSets whose drives together form one cluster. This is the chart-level equivalent of adding a Server Pool as described in [Availability and Scalability](../../upgrade-scale/availability-and-resiliency.md).
+
+To expand an existing deployment, enable pools and describe the current layout as pool 0 plus your new capacity:
+
+```yaml title="values-prod.yaml (pools)"
+pools:
+  enabled: true
+  list:
+    - {}                  # pool 0: inherits top-level values and keeps the
+                          # existing StatefulSet/pod/PVC names and data
+    - replicaCount: 4     # pool 1: new capacity (4 or 16)
+      storageclass:
+        dataStorageSize: 10Gi
+```
+
+Then apply with `helm upgrade`. Each entry may set `replicaCount` (4 or 16) and/or a `storageclass` block; omitted fields inherit the top-level values. Additional pools render as `<fullname>-pool<N>` StatefulSets; all pools share the headless service, the main service, the configuration, and the credentials.
+
+:::warning[Pools are append-only]
+
+The list index determines the StatefulSet name — never remove or reorder entries. Retire a pool with `rc admin decommission` before removing it from the list.
+
+:::
+
+What to expect during the rollout, per the chart's documentation:
+
+- **Crash/restart cycles are normal.** Pods restart until every pod of every pool is resolvable — the server refuses to start with unresolvable peers, so expect a few crash loops before the cluster converges. This is harmless.
+- **Rebalance afterwards.** After the cluster converges, run `rc admin rebalance start <alias>` to spread existing objects across the new pool.
+- The PodDisruptionBudget spans all pools: with the default `pdb.maxUnavailable: 1`, at most one pod of the whole cluster may be evicted at a time.
+
+:::note
+
+`rc` is the RustFS admin command-line client referenced by the chart documentation (`rc admin pool ls` / `expand` / `rebalance` / `decommission`). Confirm its availability and packaging with your RustFS distribution before relying on it in runbooks.
+
+:::
+
+## 8. Uninstall
+
+```bash
+helm uninstall rustfs -n rustfs
+```
+
+:::note
+
+Helm does not delete PVCs created by StatefulSet volume claim templates. If you intend to discard the data, remove the PVCs explicitly (`kubectl -n rustfs delete pvc -l app.kubernetes.io/name=rustfs`) — otherwise a later reinstall with the same release name reattaches them.
+
+:::
+
+## Next steps
+
+- [Availability and Scalability](../../upgrade-scale/availability-and-resiliency.md) — how Server Pool expansion works at the cluster level
+- [Upgrade](../../upgrade-scale/upgrade.md) — zero-downtime rolling upgrades
+- [TLS configuration](../../integration/tls-configured.md) — end-to-end TLS options

--- a/content/operations/cold-start.md
+++ b/content/operations/cold-start.md
@@ -1,0 +1,88 @@
+---
+title: "Cold Start and Quorum Loss"
+description: "This article explains how RustFS nodes behave when they start before the cluster has quorum, how to read the degraded-mode signals, and how to diagnose the most common startup failures."
+---
+
+## Degraded Startup in One Paragraph
+
+When several nodes of an erasure-coded cluster went down together (power loss, host maintenance, a crash-looping rollout) and come back one at a time, the early nodes cannot reach the storage read quorum. They do **not** exit. The process stays alive in **degraded mode**, answers S3 requests with `503`, and recovers **automatically** as soon as enough peers are online. Do not restart-loop degraded nodes — just keep starting the remaining ones.
+
+## Why One Node Cannot Serve Alone
+
+Erasure coding shards every object — including internal metadata such as IAM users and policies under `.rustfs.sys` — across the drives of a set. Reading anything back requires a read quorum of shards. With a set's drives spread over several nodes, a single node can never satisfy that quorum by itself; the cluster becomes readable once roughly half the nodes of a set are up (internal configuration objects are written with maximum parity). Distributed locking similarly needs a majority of nodes' lock RPC endpoints.
+
+## The 503 Contract
+
+While a node is not yet ready, S3 requests receive:
+
+- status `503 Service Unavailable`;
+- header `Retry-After: 5` — clients should retry, the condition is temporary;
+- header `x-rustfs-readiness-pending` naming the blocking dependency:
+  - `storage_quorum` — waiting for enough nodes/disks for the erasure read quorum;
+  - `iam` — storage is up, the IAM cache is still loading;
+  - `startup_finalization` — the last startup steps are being published.
+
+Probe the readiness endpoint for per-dependency detail:
+
+```bash
+curl -s http://<node>:9000/health/ready | jq
+```
+
+A degraded response includes a `details` object (`storage` / `iam` / `lock`, plus `kms` when configured) and a `degradedReasons` array. Verified reason values:
+
+| `degradedReasons` value | Meaning |
+| --- | --- |
+| `storage_quorum_unavailable` | Erasure read quorum not met |
+| `iam_not_ready` | IAM cache still loading |
+| `lock_quorum_unavailable` | Lock RPC majority not reachable (cluster probes only) |
+| `kms_not_ready` | Configured KMS not reachable |
+| `peer_health_unavailable` | Peer health check failing |
+| `cluster_health_timeout` | Cluster health evaluation timed out |
+| `storage_and_iam_unavailable`, `storage_and_lock_unavailable`, `iam_and_lock_unavailable`, `storage_iam_and_lock_unavailable` | Combined variants of the above |
+
+`GET /health` and `GET /health/live` stay `200` throughout — the process is alive, only readiness is pending. Point Kubernetes liveness probes at `/health` and readiness probes at `/health/ready`, or a degraded-but-recovering node will be killed mid-recovery.
+
+## Why You Should Not Restart-Loop
+
+1. **Recovery is automatic.** As soon as enough peers are online, pending nodes finish IAM bootstrap on the next retry and flip `/health/ready` to `200` on their own. Restarting does not speed this up — it throws away retry progress.
+2. **Logs tell you what is missing.** The IAM recovery loop logs `event="iam_bootstrap_retry_failed"` with an actionable `hint` field (for example, "storage read quorum not met yet; waiting for enough cluster nodes/disks to come online"). After repeated failures the level escalates from WARN to ERROR — this still does not kill the process.
+3. **A node process exiting during startup is a bug, not the design.** The fatal IAM/lock startup path was removed after v1.0.0-beta.5; upgrade if you still see nodes exit while waiting for quorum.
+
+## Tuning
+
+- `RUSTFS_STARTUP_READINESS_MAX_WAIT_SECS` (default `120`): how long startup waits for full readiness before continuing in degraded mode with background recovery. Raising it delays the listener during genuinely slow starts; lowering it surfaces degraded mode sooner. Recovery retries continue regardless of this limit.
+
+## Recommended Cold-Start Procedure
+
+1. Start all nodes (order does not matter). Early nodes sit in degraded mode.
+2. Watch readiness converge:
+
+   ```bash
+   for n in node1 node2 node3 node4; do
+     echo -n "$n: "; curl -s http://$n:9000/health/ready | jq -r '.status'
+   done
+   ```
+
+3. Once every node reports `ok`, the cluster is fully serving. If a node is still degraded **after** all peers are up, check network reachability between nodes (peer RPC ports), compare per-node clocks, then read `degradedReasons` and the `hint` field of the IAM retry logs.
+
+## Common Startup Failures
+
+These fail fast at container start (checks performed by the image entrypoint) or during listener setup, before any degraded-mode logic applies:
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `ERROR: RUSTFS_ACCESS_KEY must not be empty.` | Credential env var set to an empty string (often an unexpanded compose interpolation like `${VAR}`) | Set a real value or remove the variable |
+| `ERROR: Set either RUSTFS_ACCESS_KEY or RUSTFS_ACCESS_KEY_FILE, not both.` | Both direct and file-based credential sources configured | Keep exactly one source |
+| `ERROR: RUSTFS_ACCESS_KEY_FILE points to an unreadable file.` | Secret file missing or wrong permissions | Mount the secret and check file modes |
+| `WARNING: ... uses the default rustfsadmin credential.` | Running with default credentials | Not fatal, but set real credentials before exposing the listener — see [Credential Management](./credentials) |
+| Startup aborts with `VolumeNotFound` | The local path component of a distributed volume URL does not exist on disk — RustFS does not auto-create disk roots | Create the data directories (the container entrypoint creates local paths listed in `RUSTFS_VOLUMES`, but verify host mounts) |
+| `HTTP listener bind failed` in logs | Port 9000 (or 9001 for the console) already in use, or address unavailable | Free the port or change `RUSTFS_ADDRESS` / `RUSTFS_CONSOLE_ADDRESS` |
+
+:::note
+Keep node clocks synchronized (NTP/chrony). S3 request signing is time-sensitive, and the rolling-restart runbook explicitly lists per-node clock drift as a cause of nodes staying degraded after the cluster is otherwise back.
+:::
+
+## Related
+
+- Rolling restarts without downtime (restart one node at a time, wait for `/health/ready` = `200` before the next) follow the same readiness signals — see the availability documentation in [Availability and Resiliency](../upgrade-scale/availability-and-resiliency).
+- [Monitoring and Alerting](./monitoring) shows how to alert on `rustfs_runtime_readiness_ready` so a stuck-degraded node pages you.

--- a/content/operations/credentials.md
+++ b/content/operations/credentials.md
@@ -1,0 +1,106 @@
+---
+title: "Credential Management"
+description: "This article covers configuring RustFS root credentials via environment variables and secret files, rotating them safely, the internode RPC secret, and the MinIO-compatible environment aliases."
+---
+
+## Root Credentials
+
+RustFS reads its root (admin) credential pair from:
+
+```bash
+RUSTFS_ACCESS_KEY=<your-access-key>
+RUSTFS_SECRET_KEY=<your-secret-key>
+```
+
+If neither is provided, the server falls back to the built-in default `rustfsadmin` / `rustfsadmin`.
+
+:::warning
+The default `rustfsadmin` credentials are public and well-known. The container entrypoint prints a warning but still starts. Always set non-default credentials before exposing ports 9000/9001 beyond localhost. Additionally, a multi-node cluster running with an all-default pair **must** set `RUSTFS_RPC_SECRET` (see below) — the server refuses to derive internode RPC auth from the default secret key.
+:::
+
+## File-Based Injection (Docker/Kubernetes Secrets)
+
+Instead of putting secrets into the environment, point RustFS at files containing them:
+
+```bash
+RUSTFS_ACCESS_KEY_FILE=/run/secrets/rustfs_access_key
+RUSTFS_SECRET_KEY_FILE=/run/secrets/rustfs_secret_key
+```
+
+Equivalent CLI flags exist (`--access-key-file`, `--secret-key-file`). Rules enforced by the container entrypoint:
+
+- Only the **first line** of the file is read; surrounding whitespace and CR characters (CRLF-edited files) are trimmed. A file without a trailing newline is valid.
+- Setting both the direct variable and the `_FILE` variant for the same credential is a hard error: `Set either RUSTFS_ACCESS_KEY or RUSTFS_ACCESS_KEY_FILE, not both.`
+- An empty value, an empty file, or an unreadable file is a hard error (exit 1).
+- A file containing the default `rustfsadmin` value triggers the same warning as the direct variable.
+
+```yaml title="docker-compose example with secrets"
+services:
+  rustfs:
+    image: rustfs/rustfs:latest
+    environment:
+      - RUSTFS_ACCESS_KEY_FILE=/run/secrets/rustfs_access_key
+      - RUSTFS_SECRET_KEY_FILE=/run/secrets/rustfs_secret_key
+    secrets:
+      - rustfs_access_key
+      - rustfs_secret_key
+secrets:
+  rustfs_access_key:
+    file: ./secrets/access_key.txt
+  rustfs_secret_key:
+    file: ./secrets/secret_key.txt
+```
+
+## Rotating the Root Credentials
+
+All nodes of a cluster must run with the **same** root credential pair — internode RPC authentication is derived from it unless `RUSTFS_RPC_SECRET` is set explicitly.
+
+:::note
+The step-by-step procedure below is standard operational practice composed from verified building blocks (env/file configuration plus the verified rolling-restart readiness signals); RustFS does not currently document an online root-credential rotation API.
+:::
+
+1. If you have not already, set an explicit `RUSTFS_RPC_SECRET` (same value on all nodes) **before** the rotation. This decouples internode auth from the credential pair, so the cluster tolerates nodes temporarily running with mixed old/new root credentials during the rolling restart.
+2. Update the environment file / secret on **every** node with the new `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` (or the files behind the `_FILE` variants).
+3. Restart nodes **one at a time**, waiting for each to return `200` from `GET /health/ready` on port 9000 before restarting the next.
+4. Update every client, SDK configuration, and automation that used the old pair.
+5. Verify: sign a request with the old credentials and confirm it is rejected.
+
+## RUSTFS_RPC_SECRET (Internode RPC Auth)
+
+Nodes of a distributed cluster authenticate their internal RPC traffic with a shared secret:
+
+- If `RUSTFS_RPC_SECRET` is set, that value is used directly. Set the **same value on every node**.
+- If it is unset, the secret is **derived** (HMAC) from the active access/secret key pair — which is why all nodes must share the same root credentials.
+- Derivation **fails closed** when the secret key is the default `rustfsadmin`: a publicly known secret would yield a publicly computable RPC secret that any network peer could use to forge internode signatures. In that configuration internode RPC cannot authenticate until you either set `RUSTFS_RPC_SECRET` or configure a non-default `RUSTFS_SECRET_KEY`.
+
+When to set it explicitly:
+
+- multi-node clusters that (temporarily or otherwise) run with default root credentials;
+- before rotating root credentials, to keep internode auth stable during the rollout;
+- environments where you want internode auth independent of the S3 root credential lifecycle.
+
+```bash
+# Same value on every node
+RUSTFS_RPC_SECRET=<your-rpc-secret>
+```
+
+## Compatibility Aliases
+
+For drop-in migration, RustFS accepts credential variables under legacy and MinIO-compatible names when the canonical `RUSTFS_ACCESS_KEY` / `RUSTFS_SECRET_KEY` are not set:
+
+| Accepted alias | Canonical variable |
+| --- | --- |
+| `RUSTFS_ROOT_USER` (legacy) | `RUSTFS_ACCESS_KEY` |
+| `RUSTFS_ROOT_PASSWORD` (legacy) | `RUSTFS_SECRET_KEY` |
+| `MINIO_ROOT_USER` | `RUSTFS_ROOT_USER` → `RUSTFS_ACCESS_KEY` |
+| `MINIO_ROOT_PASSWORD` | `RUSTFS_ROOT_PASSWORD` → `RUSTFS_SECRET_KEY` |
+
+The `MINIO_` prefix mapping covers a broader allowlist of variables (address, console address, audit webhook settings, and more), applied at startup as "external-prefix compatibility mappings".
+
+:::note
+Aliases are deprecated. When one is used, the server logs a one-time warning of the form `Environment variable MINIO_ROOT_USER is deprecated, use RUSTFS_ROOT_USER instead`. Use the `RUSTFS_`-prefixed canonical names in new deployments; the canonical name always wins when both are set.
+:::
+
+## Beyond the Root Credential
+
+Day-to-day access should not use the root pair. Create scoped users, groups, policies, and service accounts through the console on port 9001 or the IAM admin APIs, and reserve the root credential for administrative operations. See the IAM documentation in the administration section.

--- a/content/operations/decommission.md
+++ b/content/operations/decommission.md
@@ -1,0 +1,130 @@
+---
+title: "Pool Decommission and Rebalance"
+description: "This article describes how to retire a server pool with the decommission workflow and how to spread existing data onto new pools with rebalance, including the admin API endpoints, progress monitoring, and abort semantics."
+---
+
+## Concepts
+
+A RustFS cluster grows by adding **server pools** — additional groups of nodes/drives listed in `RUSTFS_VOLUMES` (space-separated expansion expressions). Two data-movement operations manage pools over their lifecycle:
+
+- **Decommission** drains all objects off a pool onto the remaining active pools, so the pool can be removed from the deployment. Movement is one-directional and the pool is retired afterwards.
+- **Rebalance** redistributes existing objects across **all** pools after an expansion, so a newly added (empty) pool takes its fair share. No pool is removed.
+
+The two are mutually exclusive: rebalance refuses to start while a decommission is in progress, and both require a multi-pool deployment (single-pool clusters reject either operation because there is nowhere to move data).
+
+## When to Decommission
+
+- Retiring old hardware after adding a replacement pool.
+- Shrinking a cluster that was previously expanded.
+- Consolidating small pools into a larger one.
+
+## Prerequisites
+
+1. **At least one active pool must remain.** You cannot decommission every pool; the request is rejected if no active pool would be left.
+2. **Remaining pools need capacity.** The server verifies before starting that the free space on the remaining active pools is at least the used bytes of the pool(s) being drained **plus a 30% overhead**. Otherwise the start request fails with `insufficient target pool capacity`.
+3. **Completed pools cannot be re-decommissioned.** Completion means the pool should now be removed from the deployment configuration (`RUSTFS_VOLUMES` / Helm pool list). Failed or canceled pools may be retried.
+4. Healthy cluster: run decommission with all nodes up; the operation persists its state and resumes after restarts, but starting it on a degraded cluster adds risk.
+
+:::warning
+Decommission moves data. Take a fresh backup or verify your replication targets before draining a pool, and schedule it in a low-traffic window.
+:::
+
+## Admin API Endpoints
+
+The admin API is served on port 9000 under the `/rustfs/admin/v3` prefix (a MinIO-compatible `/minio/admin` prefix also exists). All requests must be signed (AWS Signature V4) with credentials that hold the decommission admin permission — the root credential works. The `pool` query parameter takes the pool's command-line expression exactly as configured, or a zero-based pool index with `by-id=true`.
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/rustfs/admin/v3/pools/list` | List pools and their status |
+| `GET` | `/rustfs/admin/v3/pools/status?pool=<pool>` | Status of one pool |
+| `GET` | `/rustfs/admin/v3/decommission/status[?pool=<pool>]` | Decommission progress (all pools or one) |
+| `POST` | `/rustfs/admin/v3/pools/decommission?pool=<pool>` | Start draining a pool (comma-separated multi-pool targets are queued) |
+| `POST` | `/rustfs/admin/v3/pools/cancel?pool=<pool>` | Cancel a running decommission |
+| `POST` | `/rustfs/admin/v3/pools/clear?pool=<pool>` | Clear failed/canceled decommission metadata |
+
+Example with `curl` (SigV4 signing via `--aws-sigv4`):
+
+```bash
+# Start decommissioning pool 0 (by index)
+curl -X POST \
+  --aws-sigv4 "aws:amz:us-east-1:s3" \
+  --user "<your-access-key>:<your-secret-key>" \
+  "http://<node>:9000/rustfs/admin/v3/pools/decommission?pool=0&by-id=true"
+
+# Or address the pool by its volumes expression
+curl -X POST \
+  --aws-sigv4 "aws:amz:us-east-1:s3" \
+  --user "<your-access-key>:<your-secret-key>" \
+  "http://<node>:9000/rustfs/admin/v3/pools/decommission?pool=http://server{1...4}/disk{1...4}"
+```
+
+The request can be sent to any node; if the target pool's leader is a different node, RustFS forwards the operation over the authenticated internode RPC channel.
+
+The upstream Helm chart documents the same workflow through an admin CLI as `rc admin pool ls` / `rc admin decommission` / `rc admin rebalance start <alias>`.
+
+:::note
+The `rc` admin CLI is referenced by the upstream Helm README but may not be generally available in your distribution yet. The HTTP admin API above and the RustFS console are the verified interfaces; treat `rc admin ...` commands as equivalent shorthand where the tool is available.
+:::
+
+## Monitoring Progress
+
+Poll the decommission status endpoint:
+
+```bash
+curl -s \
+  --aws-sigv4 "aws:amz:us-east-1:s3" \
+  --user "<your-access-key>:<your-secret-key>" \
+  "http://<node>:9000/rustfs/admin/v3/decommission/status" | jq
+```
+
+Each pool entry reports a `decommissionInfo` object with (field names as serialized):
+
+- `startTime`, `startSize`, `totalSize`, `currentSize`
+- `complete`, `failed`, `canceled`
+- `objectsDecommissioned`, `objectsDecommissionedFailed`
+- `bytesDecommissioned`, `bytesDecommissionedFailed`
+
+The operation is finished when `complete` is `true` and the failed counters are zero. Only one pool actively moves data at a time; additional targets in a multi-pool request wait in a queue.
+
+After completion, remove the drained pool from `RUSTFS_VOLUMES` (or the Helm `pools` list — entries there are append-only, so decommission **before** removing an entry) and restart the cluster with the new topology.
+
+## Cancel, Clear, and Rollback Semantics
+
+- **Cancel** (`POST /rustfs/admin/v3/pools/cancel?pool=<pool>`) stops the running drain. The pool is marked `canceled` and stops receiving decommission traffic; a canceled (or failed) pool can be decommissioned again later.
+- **Clear** (`POST /rustfs/admin/v3/pools/clear?pool=<pool>`) removes failed/canceled decommission metadata only, so status output is clean again.
+- **There is no data rollback.** Objects already moved to other pools stay where they are; cancel/clear never move data back. This is by design — a partially drained pool is still fully functional, just emptier.
+
+## Rebalance After Expansion
+
+After adding a pool, existing objects stay where they were written; only new writes prefer the pool with more free space. To actively spread existing data:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/rustfs/admin/v3/rebalance/start` | Start a cluster-wide rebalance (no query parameters; returns `{"id": ...}`) |
+| `GET` | `/rustfs/admin/v3/rebalance/status` | Per-pool progress: `objects`, `versions`, `bytes`, `remainingBuckets`, current `bucket`/`object`, `elapsed`, `eta` |
+| `POST` | `/rustfs/admin/v3/rebalance/stop` | Stop the rebalance |
+
+```bash
+curl -X POST \
+  --aws-sigv4 "aws:amz:us-east-1:s3" \
+  --user "<your-access-key>:<your-secret-key>" \
+  "http://<node>:9000/rustfs/admin/v3/rebalance/start"
+```
+
+Rules enforced by the server:
+
+- rejected on single-pool deployments;
+- rejected while a decommission is in progress (`cannot start rebalance while decommission is in progress`);
+- rejected when a rebalance is already running (`rebalance is already in progress`).
+
+Rebalance runs until pools converge toward equal usage ratios; you can stop it at any time — like decommission, stopping never undoes moves already made.
+
+## Local Test Rig
+
+The upstream repository ships `docker-compose.decommission.yml`, a single-container two-pool layout useful for rehearsing the workflow before touching production:
+
+```bash
+# Two pools inside one container: /data/pool0/disk{1...4} and /data/pool1/disk{1...4}
+# S3 on host port 9100, console on 9101
+docker compose -f docker-compose.decommission.yml up -d
+```

--- a/content/operations/monitoring.md
+++ b/content/operations/monitoring.md
@@ -1,0 +1,139 @@
+---
+title: "Monitoring and Alerting"
+description: "This article explains how RustFS exports metrics, traces, and logs over OTLP, how to wire the pipeline into Prometheus and Grafana, which health endpoints to probe, and which signals to alert on."
+---
+
+## How RustFS Exposes Telemetry
+
+RustFS **pushes** metrics, traces, and logs over OTLP (OpenTelemetry Protocol). It does **not** expose a native Prometheus `/metrics` scrape endpoint — there is no HTTP route on port 9000 or 9001 that serves Prometheus text format. To get RustFS metrics into Prometheus you must run an OpenTelemetry Collector that receives OTLP from RustFS and re-exposes the data in Prometheus format:
+
+```text
+RustFS (RUSTFS_OBS_ENDPOINT) --OTLP--> OpenTelemetry Collector --> Prometheus --> Grafana
+                                                              \--> Loki (logs)
+                                                              \--> Tempo / Jaeger (traces)
+```
+
+Point RustFS at the Collector with:
+
+```bash
+# OTLP over HTTP (the Collector's default HTTP receiver port is 4318; gRPC is 4317)
+RUSTFS_OBS_ENDPOINT=http://otel-collector:4318
+```
+
+Related environment variables (all defined in the server configuration):
+
+| Variable | Purpose |
+| --- | --- |
+| `RUSTFS_OBS_ENDPOINT` | Base OTLP endpoint for traces, metrics, and logs |
+| `RUSTFS_OBS_TRACE_ENDPOINT` / `RUSTFS_OBS_METRIC_ENDPOINT` / `RUSTFS_OBS_LOG_ENDPOINT` | Per-signal endpoint overrides |
+| `RUSTFS_OBS_METRICS_EXPORT_ENABLED` / `RUSTFS_OBS_TRACES_EXPORT_ENABLED` / `RUSTFS_OBS_LOGS_EXPORT_ENABLED` | Toggle each signal |
+| `RUSTFS_OBS_METER_INTERVAL` | Metric export interval |
+| `RUSTFS_OBS_SERVICE_NAME` / `RUSTFS_OBS_ENVIRONMENT` | Resource attributes attached to exported telemetry |
+| `RUSTFS_OBS_LOGGER_LEVEL` | Log verbosity (e.g. `info`) |
+
+## Reference Deployment (Docker Compose Observability Profile)
+
+The upstream `rustfs/rustfs` repository ships a complete reference stack in `docker-compose.yml` behind the `observability` profile: **otel-collector**, **Prometheus**, **Grafana**, **Loki** (logs), **Tempo** and **Jaeger** (traces). Its Collector configuration receives OTLP on 4317 (gRPC) and 4318 (HTTP) and re-exports metrics for Prometheus on port `8889`:
+
+```yaml
+# OpenTelemetry Collector (excerpt from the upstream reference config)
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]
+```
+
+Prometheus then scrapes the Collector, not RustFS:
+
+```yaml
+# prometheus.yml (excerpt)
+scrape_configs:
+  - job_name: "rustfs-app-metrics"
+    static_configs:
+      - targets: ["otel-collector:8889"]   # RustFS application metrics
+  - job_name: "otel-collector"
+    static_configs:
+      - targets: ["otel-collector:8888"]   # Collector self-metrics
+```
+
+:::note
+If Prometheus shows no `rustfs_*` series, check the chain in order: is `RUSTFS_OBS_ENDPOINT` set on every node, is the Collector reachable from the nodes, and is Prometheus scraping the Collector's `8889` exporter port.
+:::
+
+## Health Endpoints
+
+The S3 listener on port **9000** serves the probe endpoints; the console on port **9001** has its own health path.
+
+| Endpoint | Port | Meaning |
+| --- | --- | --- |
+| `GET /health`, `GET /health/live` | 9000 | Liveness — returns `200` as long as the process is up |
+| `GET /health/ready` | 9000 | Readiness — `200` only when storage, IAM, and peer health are ready; `503` otherwise |
+| `GET /minio/health/ready` | 9000 | MinIO-compatible alias of the readiness probe |
+| `GET /minio/health/cluster`, `GET /minio/health/cluster/read` | 9000 | Cluster write/read health (additionally require lock quorum) |
+| `GET /rustfs/console/health` | 9001 | Console process health |
+
+A ready node answers `200` with `"ready": true`. A degraded node answers `503` with per-dependency detail:
+
+```bash
+curl -s http://<node>:9000/health/ready | jq
+```
+
+The `details` object reports `storage` / `iam` / `lock` (and `kms` when configured), and `degradedReasons` lists machine-readable causes such as `storage_quorum_unavailable`, `iam_not_ready`, or `lock_quorum_unavailable`. See [Cold Start and Quorum Loss](./cold-start) for the full degraded-startup semantics.
+
+## Key Metrics
+
+All metric names below are exported via OTLP and appear in Prometheus after the Collector re-exports them (label set as recorded in the server source; the Collector may add resource labels). See the [Metrics Reference](../reference/metrics) for the full verified list.
+
+| Metric | Type | What it tells you |
+| --- | --- | --- |
+| `rustfs_runtime_readiness_ready` | gauge | `1` when the node is fully ready, `0` while degraded |
+| `rustfs_runtime_readiness_degraded_total` | counter (`reason`) | Degraded-readiness evaluations by reason |
+| `rustfs_scanner_objects_scanned_total` | counter | Objects visited by the background scanner |
+| `rustfs_scanner_cycles_total` | counter (`result`: success/error/partial) | Completed scanner cycles |
+| `rustfs_scanner_cycle_duration_seconds` | gauge | Duration of the last scanner cycle |
+| `rustfs_heal_task_running` | gauge (`type`, `set`) | Currently running heal tasks per erasure set |
+| `rustfs_heal_queue_delay_seconds` | histogram (`type`, `set`) | Time heal tasks spend queued before starting |
+| `rustfs_heal_task_start_total` | counter (`type`, `set`) | Heal tasks started |
+| `rustfs_capacity_current_bytes` | gauge | Current used capacity in bytes |
+| `rustfs_start_total` | counter | Process starts (spikes indicate restart loops) |
+
+## Suggested Alerts
+
+| Alert | Signal | Suggested rule |
+| --- | --- | --- |
+| Node not ready > 2 min | `rustfs_runtime_readiness_ready` gauge, or an external probe on `GET /health/ready` returning non-200 | `rustfs_runtime_readiness_ready == 0` for `2m` |
+| Restart loop | `rustfs_start_total` | `increase(rustfs_start_total[10m]) > 3` |
+| Heal backlog growing | `rustfs_heal_task_running` and `rustfs_heal_queue_delay_seconds` | sustained non-zero running tasks plus rising queue delay for `30m` |
+| Scanner stalled | `rustfs_scanner_cycles_total` | `increase(rustfs_scanner_cycles_total[24h]) == 0` |
+| Cluster used capacity watermark | `rustfs_capacity_current_bytes` | compare against your deployed raw capacity (a constant you set), e.g. `rustfs_capacity_current_bytes > 0.8 * <total-bytes>` |
+
+:::note
+Per-disk usage and disk online/offline state are currently surfaced through the console and the admin API (server/storage info), not as dedicated OTLP metrics. For a per-disk watermark alert, poll the admin API from your own exporter or watch the console dashboard.
+:::
+
+## Log Collection
+
+Where logs go is controlled by `RUSTFS_OBS_LOG_DIRECTORY`:
+
+- **Unset** — logs go to stdout. In containers, use your log driver; on systemd hosts, stdout/stderr is captured by **journald**, so `journalctl -u rustfs -f` works without extra configuration.
+- **A local directory** (e.g. `/logs`) — RustFS writes rotating log files there. Rotation is tuned with `RUSTFS_OBS_LOG_FILENAME`, `RUSTFS_OBS_LOG_ROTATION_SIZE_MB`, `RUSTFS_OBS_LOG_ROTATION_TIME`, and `RUSTFS_OBS_LOG_KEEP_FILES`.
+- **A URL** (contains `://`) — logs are shipped to a remote endpoint.
+
+When `RUSTFS_OBS_ENDPOINT` is set and log export is enabled, logs are additionally exported via OTLP; the reference stack routes them into Loki for querying from Grafana.
+
+```bash title="Example: file logs plus OTLP export"
+RUSTFS_OBS_LOG_DIRECTORY=/var/log/rustfs
+RUSTFS_OBS_LOGGER_LEVEL=info
+RUSTFS_OBS_ENDPOINT=http://otel-collector:4318
+```

--- a/content/upgrade-scale/upgrade.md
+++ b/content/upgrade-scale/upgrade.md
@@ -1,0 +1,150 @@
+---
+title: "Upgrade"
+description: "Zero-downtime rolling upgrade runbook for multi-node RustFS clusters: pre-checks, node-by-node procedure, degraded-startup semantics, rollback, and verification."
+---
+
+This runbook describes how to upgrade the RustFS binary (or container image) on a multi-node, erasure-coded cluster without losing availability, and how to read the degraded-mode signals if several nodes end up down at once.
+
+:::note[Upgrades never change the on-disk format]
+
+Upgrading the binary or container image never changes the on-disk data format. Replacing the executable and restarting is safe; no migration step runs on startup.
+
+:::
+
+## When a rolling restart applies
+
+A **rolling restart** — restarting one node at a time while the rest keep serving — covers:
+
+- Binary or container image upgrades
+- Changes to environment variables or startup parameters on individual nodes (edits to `/etc/default/rustfs`)
+
+It does **not** cover topology changes. Changing `RUSTFS_VOLUMES` — for example, adding a Server Pool — must be applied to **every** node's configuration, and all nodes must be restarted so the whole cluster agrees on the new layout; expect a short interruption while the cluster converges. See [Availability and Scalability](./availability-and-resiliency.md) for the pool expansion workflow.
+
+## Why one node at a time
+
+Erasure coding shards every object — including internal metadata such as IAM users, groups, and policies under `.rustfs.sys` — across the drives of a set. Reading data back needs a read quorum of shards online. While one node is down, the rest of the cluster keeps quorum and serves all traffic. If you take a second node down before the first is back, some erasure sets may lose write or even read quorum and requests start failing — this is the situation to avoid.
+
+## Pre-checks
+
+Before touching the first node:
+
+1. **Confirm the cluster is fully healthy.** Every node should return `200`:
+
+   ```bash
+   curl -fsS http://<node>:9000/health/ready
+   ```
+
+   Do not start a rolling upgrade on a cluster that already has offline nodes or degraded erasure sets.
+
+2. **Back up each node's configuration** (generic precaution — it holds credentials and the volume layout):
+
+   ```bash
+   sudo cp /etc/default/rustfs /etc/default/rustfs.bak-$(date +%F)
+   ```
+
+3. **Keep the currently running binary** so rollback is a file copy, not a download:
+
+   ```bash
+   sudo cp /usr/local/bin/rustfs /usr/local/bin/rustfs.previous
+   ```
+
+4. **Read the release notes** of the target version for any version-specific guidance.
+
+## Rolling upgrade procedure
+
+For each node, in any order, **one at a time**:
+
+### 1. Replace the binary
+
+```bash
+# stage the new binary, then swap it in
+sudo systemctl stop rustfs
+sudo cp rustfs-new /usr/local/bin/rustfs
+sudo chmod +x /usr/local/bin/rustfs
+```
+
+(For container deployments, update the image tag on this node instead.)
+
+### 2. Restart the node
+
+```bash
+sudo systemctl start rustfs
+```
+
+The bundled systemd unit uses `Type=notify` with `TimeoutStartSec=120s`: systemd waits for the server's readiness notification, and the timeout is sized to cover initialization plus readiness checks on slower disks or cold starts. Do not shorten it.
+
+### 3. Wait until the node reports ready
+
+```bash
+curl -fsS http://<node>:9000/health/ready
+```
+
+A ready node returns `200` with `"ready": true` in the JSON body. Only then move on to the next node.
+
+### 4. Repeat for the remaining nodes
+
+Same steps, next node — never two in parallel.
+
+## If a node comes up degraded
+
+Nodes started before the cluster has quorum (relevant when several nodes are down at once, e.g. after a power loss) come up in **degraded mode** — the process stays alive and recovers automatically:
+
+- S3 requests receive `503 Service Unavailable` with a `Retry-After: 5` header, an `x-rustfs-readiness-pending` header, and a body naming the blocking dependency: `storage_quorum` (waiting for the erasure read quorum), `iam` (storage is up, IAM cache still loading), or `startup_finalization` (last startup steps being published).
+- The IAM recovery loop retries with backoff and logs `event="iam_bootstrap_retry_failed"` with an actionable `hint` field. After repeated failures the log level escalates from WARN to ERROR — this still does not kill the process.
+- As soon as enough peers are online, pending nodes finish IAM bootstrap on the next retry and flip `/health/ready` to `200` on their own.
+
+:::warning[Do not restart-loop degraded nodes]
+
+Recovery is automatic; restarting a degraded node does not speed anything up. Just keep starting the remaining nodes and wait.
+
+:::
+
+While waiting, `/health/ready` returns per-dependency detail:
+
+```bash
+curl -s http://<node>:9000/health/ready | jq
+```
+
+The `details` object shows `storage` / `iam` / `lock` readiness, and `degradedReasons` lists machine-readable causes such as `storage_quorum_unavailable` or `lock_quorum_unavailable`.
+
+`RUSTFS_STARTUP_READINESS_MAX_WAIT_SECS` (default `120`) controls how long startup waits for full readiness before continuing in degraded mode with background recovery; recovery retries continue regardless of this limit.
+
+## Rollback
+
+Because no migration runs on startup, rollback is the same rolling procedure in reverse — one node at a time, with the previous binary:
+
+```bash
+sudo systemctl stop rustfs
+sudo cp /usr/local/bin/rustfs.previous /usr/local/bin/rustfs
+sudo systemctl start rustfs
+curl -fsS http://<node>:9000/health/ready   # wait for 200 before the next node
+```
+
+If you also changed `/etc/default/rustfs`, restore the backup taken during pre-checks before restarting.
+
+## Verification
+
+After the last node is back:
+
+1. **All nodes ready:** `curl -fsS http://<node>:9000/health/ready` returns `200` on every node.
+2. **Console check:** open the Console (`http://<node>:9001`), confirm every server is listed online and shows the new version.
+3. **Functional smoke test** with any S3 client, e.g. `mc`:
+
+   ```bash
+   mc alias set rustfs http://<node>:9000 <your-access-key> <your-secret-key>
+   mc mb rustfs/upgrade-smoke-test
+   mc cp ./somefile rustfs/upgrade-smoke-test/
+   mc cat rustfs/upgrade-smoke-test/somefile > /dev/null && echo OK
+   mc rb --force rustfs/upgrade-smoke-test
+   ```
+
+## What is not normal
+
+- A node process **exiting** with a fatal IAM/lock error during startup — that fatal path was removed after `v1.0.0-beta.5`; upgrade if you still see it.
+- A node stuck degraded **after** the whole cluster is back: check network reachability between nodes (peer RPC ports) and per-node clocks, then inspect `degradedReasons` and the `hint` field of the IAM retry logs.
+
+## Related
+
+- [Availability and Scalability](./availability-and-resiliency.md) — adding Server Pools
+- [Multiple Node Multiple Disk](../installation/linux/multiple-node-multiple-disk.md) — cluster deployment layout
+- [Node troubleshooting](../troubleshooting/node.md) — diagnosing offline nodes


### PR DESCRIPTION
## Summary (review workstream: operations — rustfs/backlog#1273)

**Kubernetes/Helm production guide** replaces the 7-line "being translated" placeholder: credential guard (the chart refuses default credentials — all three escape hatches documented from values.yaml), standalone vs distributed, the **256Mi default PVC trap** (warning callout), `/health` probes, PDB / anti-affinity / topology spread, cert-manager mTLS, full Server Pool expansion workflow (append-only, expected crash-loop during expansion, rebalance afterwards), uninstall and PVC cleanup. Every values key checked against the upstream chart; the unverified hosted chart repo URL was deliberately not invented (install from the cloned repo).

**Rolling upgrade runbook** (new page): scope (what needs rolling vs full restart), "upgrades never change the on-disk format" (from the upstream runbook), node-by-node loop gated on `curl /health/ready`, degraded-startup semantics (503 + `x-rustfs-readiness-pending`, don't restart-loop), rollback and verification.

**Operations runbooks** (new pages, all facts from source): monitoring & alerting (OTLP pipeline, verified metric names, suggested alerts, explicit "no native /metrics"), pool decommission & rebalance (six admin API endpoints from handlers, capacity prerequisites incl. the 30% overhead constant, cancel/clear semantics), cold start & quorum loss (full `degradedReasons` table, startup failure messages from entrypoint.sh), credential management (`*_KEY_FILE` injection rules, `RUSTFS_RPC_SECRET` derivation, rotation marked as generic practice).

**Full IAM reference**: overview rewrite (identity types, policy evaluation semantics from `crates/policy`), users/groups/policies (all admin API endpoints verified, 28 condition operators, built-in policy contents), service accounts & STS (AssumeRole parameters, duration clamps), OIDC guide (Keycloak + Authing, env vars verbatim from upstream runbooks).

Build: ✓ 391 pages.

---
Backed by the multi-role docs review (master issue rustfs/backlog#1277; six full reports ship in the nav PR under `docs-review/`). Technical facts verified against rustfs/rustfs@ea2e24ac.

## Rendered page previews (before / after)

<details><summary><code>/administration/iam</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/ops/administration__iam.png)

</details>
<details><summary><code>/administration/iam/oidc</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/ops/administration__iam__oidc.png)

</details>
<details><summary><code>/administration/iam/policies</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/ops/administration__iam__policies.png)

</details>
<details><summary><code>/administration/iam/sts</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/ops/administration__iam__sts.png)

</details>
<details><summary><code>/installation/cloud-native</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/ops/installation__cloud-native.png)

</details>
<details><summary><code>/operations/cold-start</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/ops/operations__cold-start.png)

</details>
<details><summary><code>/operations/credentials</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/ops/operations__credentials.png)

</details>
<details><summary><code>/operations/decommission</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/ops/operations__decommission.png)

</details>
<details><summary><code>/operations/monitoring</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/ops/operations__monitoring.png)

</details>
<details><summary><code>/upgrade-scale/upgrade</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/ops/upgrade-scale__upgrade.png)

</details>
