### PR TITLE
docs: per-tool connection examples (mc, AWS CLI, boto3, rclone)

### DIFF
--- a/content/developer/examples/aws-cli.md
+++ b/content/developer/examples/aws-cli.md
@@ -1,0 +1,71 @@
+---
+title: "AWS CLI"
+description: "Connect the AWS CLI to RustFS and perform basic object operations."
+---
+
+The [AWS CLI](https://docs.aws.amazon.com/cli/) is Amazon's official command-line tool for S3, and it works with RustFS via the `--endpoint-url` flag.
+
+## Install
+
+Follow the [official install guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html), or on macOS:
+
+```bash
+brew install awscli
+```
+
+## Configure
+
+Set your [access keys](../../administration/iam/access-token.md) and region:
+
+```bash
+aws configure
+```
+
+```text
+AWS Access Key ID [None]: <your-access-key>
+AWS Secret Access Key [None]: <your-secret-key>
+Default region name [None]: us-east-1
+Default output format [None]: json
+```
+
+Pass your RustFS address with `--endpoint-url` on every command. Replace `http://localhost:9000` with your server address. When `--endpoint-url` is set, the AWS CLI uses path-style addressing, which is what RustFS requires.
+
+:::note
+If you did not set credentials at install, the local-test default is `rustfsadmin` / `rustfsadmin` — never use it beyond a throwaway local trial.
+:::
+
+## Verify
+
+Create a bucket:
+
+```bash
+aws s3 mb s3://my-bucket --endpoint-url http://localhost:9000
+```
+
+```text
+make_bucket: my-bucket
+```
+
+Upload a file:
+
+```bash
+aws s3 cp /path/to/hello.txt s3://my-bucket/ --endpoint-url http://localhost:9000
+```
+
+```text
+upload: ../path/to/hello.txt to s3://my-bucket/hello.txt
+```
+
+List the bucket:
+
+```bash
+aws s3 ls s3://my-bucket --endpoint-url http://localhost:9000
+```
+
+```text
+2026-07-15 10:30:00         12 hello.txt
+```
+
+## Next steps
+
+Build applications against RustFS with an [S3 SDK](../sdk/index.md), or manage objects with [mc](../mc.md).

--- a/content/developer/examples/boto3.md
+++ b/content/developer/examples/boto3.md
@@ -1,0 +1,53 @@
+---
+title: "boto3 (Python)"
+description: "Connect boto3 to RustFS and perform basic object operations from Python."
+---
+
+[boto3](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) is the AWS SDK for Python and connects to RustFS through a custom endpoint.
+
+## Install
+
+```bash
+pip install boto3
+```
+
+## Configure
+
+Point the client at your RustFS endpoint. Replace `http://localhost:9000` with your server address, and use your own [access keys](../../administration/iam/access-token.md). RustFS requires path-style addressing, set via botocore `Config`:
+
+```python
+import boto3
+from botocore.config import Config
+
+s3 = boto3.client(
+    "s3",
+    endpoint_url="http://localhost:9000",
+    aws_access_key_id="<your-access-key>",
+    aws_secret_access_key="<your-secret-key>",
+    region_name="us-east-1",
+    config=Config(s3={"addressing_style": "path"}),
+)
+```
+
+## Verify
+
+Create a bucket, upload a file, and list the bucket:
+
+```python
+s3.create_bucket(Bucket="my-bucket")
+
+s3.upload_file("/path/to/hello.txt", "my-bucket", "hello.txt")
+
+for obj in s3.list_objects_v2(Bucket="my-bucket").get("Contents", []):
+    print(obj["Key"], obj["Size"])
+```
+
+Expected output:
+
+```text
+hello.txt 12
+```
+
+## Next steps
+
+See the [S3 SDK overview](../sdk/index.md) for more languages, or manage objects with [mc](../mc.md).

--- a/content/developer/examples/mc.md
+++ b/content/developer/examples/mc.md
@@ -1,0 +1,64 @@
+---
+title: "mc (MinIO Client)"
+description: "Connect the MinIO Client (mc) to RustFS and perform basic object operations."
+---
+
+[mc](https://min.io/docs/minio/linux/reference/minio-mc.html) is the MinIO command-line client for S3-compatible object storage, and it works with RustFS out of the box.
+
+## Install
+
+```bash
+brew install minio/stable/mc
+```
+
+Or download a binary from the [official install guide](https://min.io/docs/minio/linux/reference/minio-mc.html#install-mc).
+
+## Configure
+
+Create an alias pointing at your RustFS endpoint. Replace `http://localhost:9000` with your server address, and use your own [access keys](../../administration/iam/access-token.md):
+
+```bash
+mc alias set rustfs http://localhost:9000 <your-access-key> <your-secret-key>
+```
+
+```text
+Added `rustfs` successfully.
+```
+
+`mc` uses path-style requests by default, which is what RustFS expects. The default region is `us-east-1`.
+
+## Verify
+
+Create a bucket:
+
+```bash
+mc mb rustfs/my-bucket
+```
+
+```text
+Bucket created successfully `rustfs/my-bucket`.
+```
+
+Upload a file:
+
+```bash
+mc cp /path/to/hello.txt rustfs/my-bucket/
+```
+
+```text
+/path/to/hello.txt: 12 B / 12 B  100.00% 1.2 KiB/s 0s
+```
+
+List the bucket:
+
+```bash
+mc ls rustfs/my-bucket
+```
+
+```text
+[2026-07-15 10:30:00 UTC]    12B STANDARD hello.txt
+```
+
+## Next steps
+
+See the [full mc guide](../mc.md) for bucket policies, mirroring, and more operations.

--- a/content/developer/examples/meta.json
+++ b/content/developer/examples/meta.json
@@ -1,0 +1,9 @@
+{
+  "title": "Examples",
+  "pages": [
+    "[mc (MinIO Client)](/developer/examples/mc)",
+    "[AWS CLI](/developer/examples/aws-cli)",
+    "[boto3 (Python)](/developer/examples/boto3)",
+    "[rclone](/developer/examples/rclone)"
+  ]
+}

--- a/content/developer/examples/rclone.md
+++ b/content/developer/examples/rclone.md
@@ -1,0 +1,59 @@
+---
+title: "rclone"
+description: "Connect rclone to RustFS and perform basic object operations."
+---
+
+[rclone](https://rclone.org/) is a command-line program for syncing files with cloud storage and speaks the S3 protocol that RustFS implements.
+
+## Install
+
+```bash
+curl https://rclone.org/install.sh | sudo bash
+```
+
+Or see the [official install guide](https://rclone.org/install/).
+
+## Configure
+
+Add a remote to `~/.config/rclone/rclone.conf`. Replace `http://localhost:9000` with your server address, and use your own [access keys](../../administration/iam/access-token.md). `force_path_style = true` is required because RustFS uses path-style addressing:
+
+```ini title="~/.config/rclone/rclone.conf"
+[rustfs]
+type = s3
+provider = Other
+access_key_id = <your-access-key>
+secret_access_key = <your-secret-key>
+endpoint = http://localhost:9000
+region = us-east-1
+force_path_style = true
+```
+
+## Verify
+
+Create a bucket:
+
+```bash
+rclone mkdir rustfs:my-bucket
+```
+
+Upload a file:
+
+```bash
+rclone copy /path/to/hello.txt rustfs:my-bucket
+```
+
+List buckets and contents:
+
+```bash
+rclone lsd rustfs:
+rclone ls rustfs:my-bucket
+```
+
+```text
+          -1 2026-07-15 10:30:00        -1 my-bucket
+       12 hello.txt
+```
+
+## Next steps
+
+Build applications against RustFS with an [S3 SDK](../sdk/index.md), or manage objects with [mc](../mc.md).


### PR DESCRIPTION
## Summary (review workstream: per-tool examples — rustfs/backlog#1274, batch 1)

Four minimal "connect this tool to RustFS" recipes, scannable in ~30 seconds (the Cloudflare R2 examples-per-tool pattern; these double as landing pages for "rustfs + boto3"-style searches): **mc**, **AWS CLI**, **boto3**, **rclone**.

Each page: install → configure (endpoint / credentials / path-style; rclone ships a complete titled rclone.conf) → create bucket, upload, list with expected output → next steps. Unified constants and placeholder credentials; the `rustfsadmin` default-credentials caveat appears exactly once (AWS CLI page).

Build: ✓ 375 pages.

---
Backed by the multi-role docs review (master issue rustfs/backlog#1277; six full reports ship in the nav PR under `docs-review/`). Technical facts verified against rustfs/rustfs@ea2e24ac.

## Rendered page previews (before / after)

<details><summary><code>/developer/examples/aws-cli</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/examples/developer__examples__aws-cli.png)

</details>
<details><summary><code>/developer/examples/boto3</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/examples/developer__examples__boto3.png)

</details>
<details><summary><code>/developer/examples/mc</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/examples/developer__examples__mc.png)

</details>
<details><summary><code>/developer/examples/rclone</code> <em>(new page)</em></summary>

![new](https://raw.githubusercontent.com/rustfs/docs.rustfs.com/docs-review-assets/screenshots/examples/developer__examples__rclone.png)

</details>
