### PR TITLE
feat(home): add consistent icons to the landing cards

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -89,6 +89,7 @@ RUSTFS_VOLUMES="/data"
 - Plain Markdown pages use `.md`.
 - Pages that need JSX components (`<Cards>`, `<Tabs>`, `<Steps>`, etc.) must use the `.mdx` extension. Do not put JSX in `.md` files.
 - Mermaid diagrams are supported in fenced ```mermaid blocks.
+- **Card icons:** when a landing grid (`<Cards>`) uses icons, use a single consistent set of monochrome line icons from `lucide-react` (registered in `press.config.tsx`), one semantically matched icon per card, applied to **every** card in the grid — never a partial set. Do not use emoji-as-icons and do not mix brand logos (e.g. the Docker whale) with abstract icons. Pass them via `<Card icon={<Rocket />} …>`.
 
 ## Product Terminology
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -8,10 +8,10 @@ RustFS is a high-performance, distributed object storage system written in Rust,
 ## Try RustFS in 10 minutes
 
 <Cards>
-  <Card title="Quick Start" href="/installation/linux/quick-start">
+  <Card icon={<Rocket />} title="Quick Start" href="/installation/linux/quick-start">
     One command to install, log in to the Console, and store your first object.
   </Card>
-  <Card title="Run with Docker" href="/installation/docker">
+  <Card icon={<Container />} title="Run with Docker" href="/installation/docker">
     A single `docker run` for local evaluation — no server required.
   </Card>
 </Cards>
@@ -21,13 +21,13 @@ RustFS is a high-performance, distributed object storage system written in Rust,
 ### Evaluating RustFS?
 
 <Cards>
-  <Card title="What is RustFS?" href="/concepts/introduction">
+  <Card icon={<BookOpen />} title="What is RustFS?" href="/concepts/introduction">
     Positioning, features, and license.
   </Card>
-  <Card title="Architecture & Comparison" href="/concepts/architecture">
+  <Card icon={<Network />} title="Architecture & Comparison" href="/concepts/architecture">
     How it works and how it measures up against alternatives.
   </Card>
-  <Card title="Usage Limits" href="/concepts/limit">
+  <Card icon={<Gauge />} title="Usage Limits" href="/concepts/limit">
     The boundaries you should know before committing.
   </Card>
 </Cards>
@@ -35,13 +35,13 @@ RustFS is a high-performance, distributed object storage system written in Rust,
 ### Deploying and operating?
 
 <Cards>
-  <Card title="Installation Guide" href="/installation/">
+  <Card icon={<Server />} title="Installation Guide" href="/installation/">
     Linux (single-node to multi-node), Docker, Kubernetes, Windows, macOS.
   </Card>
-  <Card title="Production Checklists" href="/installation/checklists/hardware-checklists">
+  <Card icon={<ClipboardCheck />} title="Production Checklists" href="/installation/checklists/hardware-checklists">
     Hardware, network, software, and security prep.
   </Card>
-  <Card title="Operations" href="/upgrade-scale/upgrade">
+  <Card icon={<Activity />} title="Operations" href="/upgrade-scale/upgrade">
     Rolling upgrades, scaling, troubleshooting, and data healing.
   </Card>
 </Cards>
@@ -49,13 +49,13 @@ RustFS is a high-performance, distributed object storage system written in Rust,
 ### Building an application?
 
 <Cards>
-  <Card title="SDKs" href="/developer/sdk">
+  <Card icon={<Code />} title="SDKs" href="/developer/sdk">
     Java, Python, Go, Rust, JavaScript/TypeScript — any S3 client works.
   </Card>
-  <Card title="Tool Examples" href="/developer/examples/mc">
+  <Card icon={<Terminal />} title="Tool Examples" href="/developer/examples/mc">
     Minimal recipes for mc, AWS CLI, boto3, and rclone.
   </Card>
-  <Card title="Reference" href="/reference/environment-variables">
+  <Card icon={<Library />} title="Reference" href="/reference/environment-variables">
     Environment variables, CLI, ports, limits, and glossary.
   </Card>
 </Cards>

--- a/press.config.tsx
+++ b/press.config.tsx
@@ -9,6 +9,20 @@ import defaultMdxComponents, { createRelativeLink } from "fumadocs-ui/mdx";
 import { docs } from "./.source/server";
 import { Mermaid } from "./src/components/mermaid";
 import { Tab, Tabs } from "./src/components/tabs";
+// Lucide icons registered for use in MDX (e.g. <Card icon={<Rocket />} />).
+import {
+  Rocket,
+  Container,
+  BookOpen,
+  Network,
+  Gauge,
+  Server,
+  ClipboardCheck,
+  Activity,
+  Code,
+  Terminal,
+  Library,
+} from "lucide-react";
 
 const isDev = import.meta.env.DEV;
 
@@ -211,6 +225,18 @@ gtag('config', 'G-TWW7WMTWL9');`,
           Mermaid,
           Tab,
           Tabs,
+          // Lucide icons for <Card icon={<Rocket />} /> on landing pages.
+          Rocket,
+          Container,
+          BookOpen,
+          Network,
+          Gauge,
+          Server,
+          ClipboardCheck,
+          Activity,
+          Code,
+          Terminal,
+          Library,
         };
       },
     }),


### PR DESCRIPTION
## Summary

Adds a consistent set of monochrome line icons to the homepage landing cards. Previously the cards were text-only; each card now carries one semantically matched `lucide-react` icon in the standard Fumadocs card icon box.

### Icon mapping
| Card | Icon |
|---|---|
| Quick Start | `Rocket` |
| Run with Docker | `Container` |
| What is RustFS? | `BookOpen` |
| Architecture & Comparison | `Network` |
| Usage Limits | `Gauge` |
| Installation Guide | `Server` |
| Production Checklists | `ClipboardCheck` |
| Operations | `Activity` |
| SDKs | `Code` |
| Tool Examples | `Terminal` |
| Reference | `Library` |

### How
- Register the eleven icons in `press.config.tsx` `getMdxComponents` so they're usable in MDX, then `<Card icon={<Rocket />} …>` in `content/index.mdx`.
- One consistent line-icon family, applied to **every** card — no emoji, no mixed brand logos (kept the Docker card on an abstract `Container` icon rather than the Docker whale for visual consistency).

### Convention
Documented in `STYLE.md` (and the `rustfs-docs` skill) so future landing grids follow the same rule.

`npm run build` ✓ (295 pages, all eleven `lucide-*` icons present in the built HTML); `docs:check` ✓.
