### PR TITLE
docs: add second batch of tool examples (s3cmd, Terraform, aws-sdk-js/go)

### DIFF
--- a/content/developer/examples/aws-sdk-go.md
+++ b/content/developer/examples/aws-sdk-go.md
@@ -1,0 +1,55 @@
+---
+title: "AWS SDK for Go"
+description: "Connect the AWS SDK for Go v2 to RustFS and perform basic object operations."
+---
+
+The [AWS SDK for Go v2](https://aws.github.io/aws-sdk-go-v2/docs/) connects to RustFS through a custom base endpoint. This is the minimal connection recipe; see the [Go SDK guide](../sdk/go.md) for a full program.
+
+## Install
+
+```bash
+go get github.com/aws/aws-sdk-go-v2/aws
+go get github.com/aws/aws-sdk-go-v2/credentials
+go get github.com/aws/aws-sdk-go-v2/service/s3
+```
+
+## Configure
+
+Replace `http://localhost:9000` with your server address and use your own [access keys](../../administration/iam/access-token.md). RustFS requires path-style addressing (`UsePathStyle: true`):
+
+```go {9,11}
+import (
+    "github.com/aws/aws-sdk-go-v2/aws"
+    "github.com/aws/aws-sdk-go-v2/credentials"
+    "github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+cfg := aws.Config{
+    Region:      "us-east-1",
+    Credentials: aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider("<your-access-key>", "<your-secret-key>", "")),
+}
+client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+    o.BaseEndpoint = aws.String("http://localhost:9000")
+    o.UsePathStyle = true
+})
+```
+
+## Verify
+
+```go
+ctx := context.Background()
+client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String("my-bucket")})
+
+out, _ := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+for _, b := range out.Buckets {
+    fmt.Println(*b.Name)
+}
+```
+
+```text
+my-bucket
+```
+
+## Next steps
+
+See the full [Go SDK guide](../sdk/go.md), or manage objects with [mc](../mc.md).

--- a/content/developer/examples/aws-sdk-js.md
+++ b/content/developer/examples/aws-sdk-js.md
@@ -1,0 +1,46 @@
+---
+title: "AWS SDK for JavaScript"
+description: "Connect the AWS SDK for JavaScript v3 to RustFS and perform basic object operations from Node.js."
+---
+
+The [AWS SDK for JavaScript v3](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/) connects to RustFS through a custom endpoint. This is the minimal connection recipe; see the [JavaScript SDK guide](../sdk/javascript.md) for a full program.
+
+## Install
+
+```bash
+npm install @aws-sdk/client-s3
+```
+
+## Configure
+
+Replace `http://localhost:9000` with your server address and use your own [access keys](../../administration/iam/access-token.md). RustFS requires path-style addressing (`forcePathStyle: true`):
+
+```javascript title="index.mjs" {8}
+import { S3Client, CreateBucketCommand, PutObjectCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+import { readFileSync } from "node:fs";
+
+const s3 = new S3Client({
+  endpoint: "http://localhost:9000",
+  region: "us-east-1",
+  credentials: { accessKeyId: "<your-access-key>", secretAccessKey: "<your-secret-key>" },
+  forcePathStyle: true,
+});
+```
+
+## Verify
+
+```javascript
+await s3.send(new CreateBucketCommand({ Bucket: "my-bucket" }));
+await s3.send(new PutObjectCommand({ Bucket: "my-bucket", Key: "hello.txt", Body: readFileSync("/path/to/hello.txt") }));
+
+const out = await s3.send(new ListObjectsV2Command({ Bucket: "my-bucket" }));
+for (const obj of out.Contents ?? []) console.log(obj.Key, obj.Size);
+```
+
+```text
+hello.txt 12
+```
+
+## Next steps
+
+See the full [JavaScript SDK guide](../sdk/javascript.md), or manage objects with [mc](../mc.md).

--- a/content/developer/examples/meta.json
+++ b/content/developer/examples/meta.json
@@ -3,7 +3,11 @@
   "pages": [
     "[mc (MinIO Client)](/developer/examples/mc)",
     "[AWS CLI](/developer/examples/aws-cli)",
+    "[s3cmd](/developer/examples/s3cmd)",
+    "[rclone](/developer/examples/rclone)",
     "[boto3 (Python)](/developer/examples/boto3)",
-    "[rclone](/developer/examples/rclone)"
+    "[AWS SDK for JavaScript](/developer/examples/aws-sdk-js)",
+    "[AWS SDK for Go](/developer/examples/aws-sdk-go)",
+    "[Terraform](/developer/examples/terraform)"
   ]
 }

--- a/content/developer/examples/s3cmd.md
+++ b/content/developer/examples/s3cmd.md
@@ -1,0 +1,56 @@
+---
+title: "s3cmd"
+description: "Connect s3cmd to RustFS and perform basic object operations from the command line."
+---
+
+[s3cmd](https://s3tools.org/s3cmd) is a command-line client for S3-compatible storage. Point it at your RustFS endpoint with a small config file.
+
+## Install
+
+```bash
+# macOS
+brew install s3cmd
+# Debian/Ubuntu
+sudo apt install s3cmd
+# or via pip
+pip install s3cmd
+```
+
+## Configure
+
+Create `~/.s3cfg`. Replace `localhost:9000` with your server address and use your own [access keys](../../administration/iam/access-token.md). RustFS uses path-style addressing, so set the bucket host to the same endpoint:
+
+```ini title="~/.s3cfg"
+[default]
+access_key = <your-access-key>
+secret_key = <your-secret-key>
+host_base = localhost:9000
+host_bucket = localhost:9000
+use_https = False
+signature_v2 = False
+```
+
+:::note
+
+Set `use_https = True` and point at port `9000` if you have [configured TLS](../../integration/tls-configured.md).
+
+:::
+
+## Verify
+
+Create a bucket, upload a file, and list it:
+
+```bash
+s3cmd mb s3://my-bucket
+s3cmd put /path/to/hello.txt s3://my-bucket/hello.txt
+s3cmd ls s3://my-bucket
+```
+
+```text
+upload: '/path/to/hello.txt' -> 's3://my-bucket/hello.txt'  [1 of 1]
+2026-07-16 10:00        12   s3://my-bucket/hello.txt
+```
+
+## Next steps
+
+See the [SDK overview](../sdk/index.md) to connect an application, or manage objects with [mc](../mc.md).

--- a/content/developer/examples/terraform.md
+++ b/content/developer/examples/terraform.md
@@ -1,0 +1,56 @@
+---
+title: "Terraform"
+description: "Manage RustFS buckets and objects with Terraform using the AWS provider pointed at a custom endpoint."
+---
+
+The [Terraform AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest) works against RustFS when you point its S3 endpoint at your server and enable path-style addressing.
+
+## Configure
+
+Replace `http://localhost:9000` with your server address and use your own [access keys](../../administration/iam/access-token.md). The skip flags stop the provider from calling AWS-only metadata and STS endpoints:
+
+```hcl title="main.tf"
+provider "aws" {
+  access_key                  = "<your-access-key>"
+  secret_key                  = "<your-secret-key>"
+  region                      = "us-east-1"
+  s3_use_path_style           = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    s3 = "http://localhost:9000"
+  }
+}
+
+resource "aws_s3_bucket" "demo" {
+  bucket = "my-bucket"
+}
+
+resource "aws_s3_object" "hello" {
+  bucket = aws_s3_bucket.demo.id
+  key    = "hello.txt"
+  source = "/path/to/hello.txt"
+}
+```
+
+## Apply
+
+```bash
+terraform init
+terraform apply
+```
+
+```text
+Plan: 2 to add, 0 to change, 0 to destroy.
+...
+aws_s3_bucket.demo: Creation complete after 0s [id=my-bucket]
+aws_s3_object.hello: Creation complete after 0s [id=hello.txt]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+```
+
+## Next steps
+
+See the [SDK overview](../sdk/index.md) to connect an application, or the [AWS CLI example](aws-cli.md) for ad-hoc commands.


### PR DESCRIPTION
## Summary

Completes the per-tool examples set (backlog rustfs/backlog#1274, second batch). Adds four `content/developer/examples/` pages, each a ~30-second connect-and-verify recipe:

- **s3cmd** — new: `~/.s3cfg` with path-style host, `mb`/`put`/`ls`
- **Terraform** — new: AWS provider with a custom S3 endpoint (`s3_use_path_style = true` + skip flags), `aws_s3_bucket`/`aws_s3_object`
- **AWS SDK for JavaScript** — minimal v3 client (`forcePathStyle: true`), links to the full JS SDK guide
- **AWS SDK for Go** — minimal v2 client (`UsePathStyle: true`), links to the full Go SDK guide

All use the canonical constants (`localhost:9000`, `us-east-1`, `my-bucket`, placeholder credentials) and enable RustFS path-style addressing. Added to the Examples `meta.json`.

`npm run docs:check` ✓ · `npm run build` ✓ (311 pages).
