### PR TITLE
fix: redirect legacy documentation URLs

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -19,6 +19,7 @@
 /integration/nginx /developer/integration/reverse-proxy/nginx 301
 /concepts/architecture / 301
 /concepts/comparison / 301
+/concepts/comparison.html / 301
 /concepts/glossary /reference 301
 /concepts/introduction / 301
 /concepts/limit /reference 301
@@ -31,6 +32,11 @@
 /installation/checklists/security-checklists /installation/requirement/checklists/security-checklists 301
 /installation/checklists/software-checklists /installation/requirement/checklists/software-checklists 301
 /installation/docker /installation/container/docker 301
+/installation/docker/ /installation/container/docker 301
+/features/logging /operations/observability 301
+/features/integration/ /developer/integration 301
+/administration/iam/access-token.html /security-compliance/iam/access-token 301
+/features/replication/ /administration/data/bucket/replication 301
 /operations/cold-start /operations/status-check 301
 /operations/decommission /operations/scaling/storage-pool-decommission 301
 /operations/monitoring /operations/observability 301

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "redirects": [
+    {
+      "source": "/installation/docker/",
+      "destination": "/installation/container/docker",
+      "statusCode": 301
+    },
+    {
+      "source": "/concepts/comparison.html",
+      "destination": "/",
+      "statusCode": 301
+    },
+    {
+      "source": "/features/logging",
+      "destination": "/operations/observability",
+      "statusCode": 301
+    },
+    {
+      "source": "/features/integration/",
+      "destination": "/developer/integration",
+      "statusCode": 301
+    },
+    {
+      "source": "/administration/iam/access-token.html",
+      "destination": "/security-compliance/iam/access-token",
+      "statusCode": 301
+    },
+    {
+      "source": "/features/replication/",
+      "destination": "/administration/data/bucket/replication",
+      "statusCode": 301
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add exact HTTP 301 redirects for six Google-indexed legacy documentation URLs
- route each legacy URL to its current canonical page
- keep the existing `_redirects` manifest in sync with the Vercel configuration

## Why

The documentation reorganization moved or removed the indexed paths, causing those URLs to return 404 responses. The production site is served by Vercel, so `vercel.json` is required for the redirects to execute at the edge; `public/_redirects` alone is not interpreted by Vercel.

## Impact

Visitors and search crawlers reaching the old URLs now receive HTTP 301 responses and land on the corresponding current documentation pages.

## Validation

- `npm run docs:check`
- `npm run build`
- validated `vercel.json` against the official Vercel configuration schema
- confirmed every redirect destination exists in the production build output
