### PR TITLE
docs: improve sidebar navigation

### DIFF
--- a/content/en/administration/meta.json
+++ b/content/en/administration/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Administration",
+  "icon": "Settings",
   "defaultOpen": true,
   "pages": [
     "[Console](/en/administration/console)",

--- a/content/en/developer/meta.json
+++ b/content/en/developer/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Developer",
+  "icon": "CodeXml",
   "defaultOpen": false,
   "pages": [
     "sdk",

--- a/content/en/installation/meta.json
+++ b/content/en/installation/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Installation",
+  "icon": "Download",
   "defaultOpen": true,
   "pages": [
     "requirement",

--- a/content/en/operations/meta.json
+++ b/content/en/operations/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Operations & Observability",
+  "icon": "Activity",
   "defaultOpen": true,
   "pages": [
     "rc",

--- a/content/en/operations/rc.mdx
+++ b/content/en/operations/rc.mdx
@@ -1,5 +1,5 @@
 ---
-title: "rc"
+title: "CLI Client (rc)"
 description: "Install the RustFS command-line client and use it to connect to and inspect a RustFS cluster."
 ---
 

--- a/content/en/reference/meta.json
+++ b/content/en/reference/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Reference",
+  "icon": "BookOpen",
   "defaultOpen": false,
   "pages": [
     "environment-variables",

--- a/content/en/security-compliance/meta.json
+++ b/content/en/security-compliance/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Security & Compliance",
+  "icon": "ShieldCheck",
   "defaultOpen": true,
   "pages": [
     "iam",

--- a/content/en/troubleshooting/meta.json
+++ b/content/en/troubleshooting/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Troubleshooting",
+  "icon": "Wrench",
   "defaultOpen": false,
   "pages": [
     "driver",

--- a/content/zh/administration/meta.json
+++ b/content/zh/administration/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "管理",
+  "icon": "Settings",
   "defaultOpen": true,
   "pages": [
     "[控制台](/zh/administration/console)",

--- a/content/zh/developer/meta.json
+++ b/content/zh/developer/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "开发者",
+  "icon": "CodeXml",
   "defaultOpen": false,
   "pages": [
     "sdk",

--- a/content/zh/installation/meta.json
+++ b/content/zh/installation/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "安装",
+  "icon": "Download",
   "defaultOpen": true,
   "pages": [
     "requirement",

--- a/content/zh/operations/meta.json
+++ b/content/zh/operations/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "运维与可观测性",
+  "icon": "Activity",
   "defaultOpen": true,
   "pages": [
     "rc",

--- a/content/zh/operations/rc.mdx
+++ b/content/zh/operations/rc.mdx
@@ -1,5 +1,5 @@
 ---
-title: "rc"
+title: "命令行客户端（rc）"
 description: "安装 RustFS 命令行客户端，并使用它连接和检查 RustFS 集群。"
 ---
 

--- a/content/zh/reference/meta.json
+++ b/content/zh/reference/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "参考",
+  "icon": "BookOpen",
   "defaultOpen": false,
   "pages": [
     "environment-variables",

--- a/content/zh/security-compliance/meta.json
+++ b/content/zh/security-compliance/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "安全与合规",
+  "icon": "ShieldCheck",
   "defaultOpen": true,
   "pages": [
     "iam",

--- a/content/zh/troubleshooting/meta.json
+++ b/content/zh/troubleshooting/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "故障排除",
+  "icon": "Wrench",
   "defaultOpen": false,
   "pages": [
     "driver",

--- a/press.config.tsx
+++ b/press.config.tsx
@@ -1,4 +1,5 @@
 import { defineConfig } from "fumapress";
+import { lucideIconsPlugin } from "fumadocs-core/source/plugins/lucide-icons";
 import { fumadocsMdx } from "fumapress/adapters/mdx";
 import { flexsearchPlugin } from "fumapress/plugins/flexsearch";
 import { llmsPlugin } from "fumapress/plugins/llms.txt";
@@ -79,6 +80,9 @@ function createSidebarFooter(locale: keyof typeof layoutLabels) {
 export default defineConfig({
   content: docs.toFumadocsSource(),
   translations,
+  loaderOptions: {
+    plugins: [lucideIconsPlugin()],
+  },
   site: {
     name: "RustFS Documentation",
     baseUrl: isDev ? "http://localhost:3000" : "https://docs.rustfs.com",


### PR DESCRIPTION
## Summary

- add semantic Lucide icons to all seven top-level documentation sidebar groups in both English and Chinese
- enable Fumadocs' `lucideIconsPlugin` so icon names render as SVG icons
- rename the `rc` sidebar entry to `CLI Client (rc)` in English and `命令行客户端（rc）` in Chinese
- follow the visual pattern used by the FumaPress documentation sidebar

## Why

The top-level sidebar groups were visually indistinguishable at a glance, and the `rc` label did not explain what the page covered. Semantic icons and a descriptive client label make the navigation easier to scan while retaining the executable name readers use in commands.

## User impact

Readers can identify the primary documentation sections and the RustFS command-line client more quickly in either locale. Page routes and navigation structure are unchanged.

## Validation

- `npm run docs:check`
- `npm run types:check`
- `npm run build`
- verified the localized labels and Lucide icons appear in generated output
