### PR TITLE
fix: update blog navigation link

### DIFF
--- a/press.config.tsx
+++ b/press.config.tsx
@@ -231,7 +231,7 @@ gtag('config', 'G-TWW7WMTWL9');`,
             url: "https://github.com/rustfs/rustfs/discussions",
             external: true,
           },
-          { text: labels.blog, url: "https://rustfs.dev", external: true },
+          { text: labels.blog, url: "https://rustfs.com/blog", external: true },
           {
             type: "icon" as const,
             label: "Twitter",


### PR DESCRIPTION
## Summary

- update the top navigation Blog URL from `https://rustfs.dev` to `https://rustfs.com/blog`

## Validation

- `npm run types:check`
- `npm run docs:check`
- `npm run build`