### PR TITLE
docs: point navbar demo link to rustfs.com/demo

### DIFF
--- a/press.config.tsx
+++ b/press.config.tsx
@@ -292,7 +292,7 @@ gtag('config', 'G-TWW7WMTWL9');`,
           { text: labels.installation, url: `${docsUrl}/installation` },
           { text: "MCP", url: `${docsUrl}/developer/mcp` },
           { text: "SDK", url: `${docsUrl}/developer/sdk` },
-          { text: labels.demo, url: "https://play.rustfs.com", external: true },
+          { text: labels.demo, url: "https://rustfs.com/demo/", external: true },
           {
             text: labels.community,
             url: "https://github.com/rustfs/rustfs/discussions",


### PR DESCRIPTION
## Summary
- Update the navbar **Demo** link to point to https://rustfs.com/demo/ (previously https://play.rustfs.com)

## Changes
- `press.config.tsx`: navbar links config only; built `dist/` output will pick this up on next build