### PR TITLE
fix: avoid Cloudflare _redirects limit while keeping locale redirects

### DIFF
--- a/scripts/language-redirects.mjs
+++ b/scripts/language-redirects.mjs
@@ -4,27 +4,6 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_REDIRECTS = path.join(ROOT, 'public', '_redirects');
-const LOCALES = ['en', 'zh', 'de', 'fr', 'ja'];
-
-/** @param {string} pathname */
-function isLocalizedPath(pathname) {
-  return LOCALES.some((locale) => pathname === `/${locale}` || pathname.startsWith(`/${locale}/`));
-}
-
-/** @param {string} source @param {string} locale */
-function localizeSource(source, locale) {
-  if (!source.startsWith('/')) return source;
-  if (isLocalizedPath(source)) return source;
-  return `/${locale}${source}`;
-}
-
-/** @param {string} target @param {string} locale */
-function localizeTarget(target, locale) {
-  if (!target.startsWith('/')) return target;
-  if (isLocalizedPath(target)) return target;
-  if (target === '/') return `/${locale}`;
-  return `/${locale}${target}`;
-}
 
 /** @returns {Map<string, string>} */
 export function collectLanguageRedirects() {
@@ -40,15 +19,9 @@ export function collectLanguageRedirects() {
     const status = match[3];
     if (!source || !target || !status) continue;
 
-    // Keep the original unprefixed rule exactly as declared in public/_redirects.
+    // Keep only base rules in _redirects to stay below Cloudflare's 100 dynamic rule limit.
+    // Locale-aware variants are resolved at runtime by worker.mjs.
     rules.set(source, `${target} ${status}`);
-
-    // Also emit language-prefixed variants, e.g. /zh/foo -> /zh/bar.
-    for (const locale of LOCALES) {
-      const localizedSource = localizeSource(source, locale);
-      const localizedTarget = localizeTarget(target, locale);
-      rules.set(localizedSource, `${localizedTarget} ${status}`);
-    }
   }
 
   return rules;

--- a/worker.mjs
+++ b/worker.mjs
@@ -1,4 +1,5 @@
 let redirectRulesPromise;
+const LOCALES = ["en", "zh", "de", "fr", "ja"];
 
 async function loadRedirectRules(env) {
   // Use the built _redirects file from the assets bundle so build-time generated rules are honored.
@@ -58,13 +59,49 @@ function matchRedirect(pathname, rules) {
   return null;
 }
 
+function splitLocale(pathname) {
+  const parts = pathname.split("/").filter(Boolean);
+  if (parts.length === 0) return { locale: null, remainder: pathname };
+
+  const locale = parts[0];
+  if (!LOCALES.includes(locale)) return { locale: null, remainder: pathname };
+
+  const remainder = `/${parts.slice(1).join("/")}`;
+  return { locale, remainder: remainder === "/" ? "/" : remainder };
+}
+
+function isLocalizedPath(pathname) {
+  return LOCALES.some((locale) => pathname === `/${locale}` || pathname.startsWith(`/${locale}/`));
+}
+
+function applyLocaleToTarget(target, locale) {
+  if (!target.startsWith("/")) return target;
+  if (isLocalizedPath(target)) return target;
+  if (target === "/") return `/${locale}`;
+  return `/${locale}${target}`;
+}
+
 export default {
   async fetch(request, env) {
     const method = request.method.toUpperCase();
     if (method === "GET" || method === "HEAD") {
       const url = new URL(request.url);
       const rules = await getRedirectRules(env);
-      const matched = matchRedirect(url.pathname, rules);
+      let matched = matchRedirect(url.pathname, rules);
+
+      // Locale-aware fallback: /zh/foo can reuse base rule /foo -> /bar as /zh/bar.
+      if (!matched) {
+        const { locale, remainder } = splitLocale(url.pathname);
+        if (locale) {
+          const baseMatch = matchRedirect(remainder, rules);
+          if (baseMatch) {
+            matched = {
+              status: baseMatch.status,
+              target: applyLocaleToTarget(baseMatch.target, locale),
+            };
+          }
+        }
+      }
 
       if (matched) {
         const targetUrl = new URL(matched.target, url);


### PR DESCRIPTION
## Problem
Cloudflare deployment failed with:
- Invalid _redirects configuration
- Maximum number of dynamic _redirects rules limit of 100 exceeded

## Fix
- Keep generated dist/public/_redirects to base rules only (47 rules).
- Move locale-aware redirect expansion to worker.mjs runtime fallback:
  - /zh/old-path reuses /old-path -> /new-path as /zh/new-path.
- Preserve existing exact/wildcard redirect behavior and query strings.

## Verification
- node scripts/add-language-redirects.mjs now outputs 47 rules.
- Syntax checks for modified files pass.
