### PR TITLE
docs: fix Docker log directory and non-root UID in container examples

### DIFF
--- a/content/de/developer/integration/big-data/iceberg.md
+++ b/content/de/developer/integration/big-data/iceberg.md
@@ -33,14 +33,12 @@ Create a working directory:
 mkdir rustfs-iceberg
 cd rustfs-iceberg
 ```
-
 Create an environment file and replace both credential placeholders:
 
 ```ini title=".env"
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Use dedicated credentials for the warehouse bucket. Do not commit `.env` to source control.
 
 Create the Spark catalog configuration:
@@ -57,7 +55,6 @@ spark.sql.catalog.demo.s3.path-style-access true
 spark.sql.defaultCatalog demo
 spark.sql.catalogImplementation in-memory
 ```
-
 Path-style access is required for this container-network endpoint. The hostname `rustfs` is resolvable only inside the Compose network; clients running on the host use `http://localhost:9000` instead.
 
 Create the Compose file:
@@ -74,7 +71,7 @@ services:
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     volumes:
       - rustfs-data:/data
     ports:
@@ -145,7 +142,6 @@ networks:
 volumes:
   rustfs-data:
 ```
-
 The [`rc` image](https://github.com/rustfs/cli) provides the official RustFS command-line client. The initializer checks for `my-bucket` before creating it, so repeated starts do not delete existing warehouse data. The RustFS volume preserves warehouse objects across container recreation.
 
 :::warning[Image versions]
@@ -161,20 +157,17 @@ Resolve the Compose file before starting containers:
 ```bash
 docker compose config
 ```
-
 Start the services and wait for the bucket initializer to finish:
 
 ```bash
 docker compose up -d
 docker compose ps -a
 ```
-
 The `create-bucket` service should show an exit code of `0`. Check its logs if it does not complete:
 
 ```bash
 docker compose logs create-bucket
 ```
-
 Open the RustFS Console at `http://localhost:9001`. The REST catalog is available at `http://localhost:8181`, and the Spark notebook server is available at `http://localhost:8888`.
 
 ## 3. Create and query an Iceberg table
@@ -184,7 +177,6 @@ Start Spark SQL:
 ```bash
 docker compose exec spark-iceberg spark-sql
 ```
-
 Create a namespace and a partitioned table:
 
 ```sql
@@ -200,7 +192,6 @@ CREATE TABLE demo.nyc.taxis
 )
 PARTITIONED BY (vendor_id);
 ```
-
 Insert and query sample rows:
 
 ```sql
@@ -213,7 +204,6 @@ VALUES
 
 SELECT * FROM demo.nyc.taxis ORDER BY trip_id;
 ```
-
 The query should return four rows:
 
 ```text
@@ -222,7 +212,6 @@ The query should return four rows:
 2  1000373  0.9  9.01   N
 1  1000374  8.4  42.13  Y
 ```
-
 ## 4. Verify objects in RustFS
 
 List the warehouse from the bucket-initializer image:
@@ -231,7 +220,6 @@ List the warehouse from the bucket-initializer image:
 docker compose run --rm --entrypoint /bin/sh create-bucket -c \
   '/usr/bin/rc alias set rustfs http://rustfs:9000 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY" >/dev/null && /usr/bin/rc find rustfs/my-bucket/warehouse'
 ```
-
 The output should include Iceberg metadata and data objects below the `warehouse/nyc/taxis` prefix. You can also inspect the `my-bucket` bucket in the RustFS Console.
 
 ## 5. Stop or reset the stack
@@ -241,13 +229,11 @@ Stop the containers while keeping the RustFS data volume:
 ```bash
 docker compose down
 ```
-
 To delete the local warehouse and start from an empty RustFS volume, explicitly include `--volumes`:
 
 ```bash
 docker compose down --volumes
 ```
-
 ## Troubleshooting
 
 ### Spark cannot reach RustFS
@@ -263,7 +249,6 @@ Check that the credentials in `.env` match the RustFS credentials and that the `
 ```bash
 docker compose logs create-bucket rest
 ```
-
 The REST catalog property uses doubled underscores in `CATALOG_IO__IMPL` and `CATALOG_S3_PATH__STYLE__ACCESS`; the fixture converts them to the dotted and hyphenated Iceberg property names.
 
 ## Next steps

--- a/content/de/developer/integration/big-data/milvus.md
+++ b/content/de/developer/integration/big-data/milvus.md
@@ -34,14 +34,12 @@ Create a working directory:
 mkdir rustfs-milvus
 cd rustfs-milvus
 ```
-
 Create an environment file and replace both credential placeholders:
 
 ```ini title=".env"
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Use dedicated credentials for the Milvus bucket. Do not commit `.env` to source control.
 
 Create the Milvus storage override:
@@ -61,7 +59,6 @@ minio:
   region: us-east-1
   useVirtualHost: false
 ```
-
 `useVirtualHost: false` selects path-style S3 requests. The hostname `rustfs` resolves inside the Compose network; clients on the host use `http://localhost:9000`.
 
 Create the Compose file:
@@ -100,7 +97,7 @@ services:
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     volumes:
       - rustfs-data:/data
     ports:
@@ -185,7 +182,6 @@ volumes:
   rustfs-data:
   milvus-data:
 ```
-
 The `create-bucket` service uses the official [`rc`](https://github.com/rustfs/cli) image and exits after ensuring that `my-bucket` exists. Named volumes preserve etcd metadata, RustFS objects, and Milvus local data when containers are recreated.
 
 :::warning[Protect local service ports]
@@ -201,20 +197,17 @@ Resolve the Compose file before starting containers:
 ```bash
 docker compose config
 ```
-
 Start the services:
 
 ```bash
 docker compose up -d
 docker compose ps -a
 ```
-
 The `create-bucket` service should exit with code `0`, and `etcd`, `rustfs`, and `standalone` should become healthy. Inspect logs if a service does not reach its expected state:
 
 ```bash
 docker compose logs create-bucket rustfs standalone
 ```
-
 Open these local interfaces:
 
 - RustFS Console: `http://localhost:9001`
@@ -232,7 +225,6 @@ python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install "pymilvus==2.6.0"
 ```
-
 Create a test script:
 
 ```python title="verify_milvus.py"
@@ -269,13 +261,11 @@ results = client.search(
 print(results)
 client.close()
 ```
-
 Run the script:
 
 ```bash
 python verify_milvus.py
 ```
-
 The result should rank the row with ID `1` first. Open Attu and confirm that the `rustfs_demo` collection contains three entities.
 
 ## 4. Verify Milvus objects in RustFS
@@ -286,7 +276,6 @@ Use the bucket-initializer image to list objects below the configured `milvus` r
 docker compose run --rm --entrypoint /bin/sh create-bucket -c \
   '/usr/bin/rc alias set rustfs http://rustfs:9000 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY" --region us-east-1 --bucket-lookup path >/dev/null && /usr/bin/rc find rustfs/my-bucket/milvus'
 ```
-
 The output should contain objects created by Milvus below the `milvus/` prefix. You can also open `my-bucket` in the RustFS Console.
 
 Milvus may buffer or compact data before every expected object appears. The successful insert, flush, query, and RustFS object listing together validate the integration path.
@@ -298,13 +287,11 @@ Stop the containers while retaining all named volumes:
 ```bash
 docker compose down
 ```
-
 To delete the local test data, including the Milvus bucket contents and etcd metadata, explicitly remove the volumes:
 
 ```bash
 docker compose down --volumes
 ```
-
 :::warning[Reset removes the test data]
 
 The `--volumes` option permanently deletes the named volumes used by this Compose project. Do not run it against data you need to retain.
@@ -322,7 +309,6 @@ Confirm that `useVirtualHost` remains `false` and that the credential values pas
 ```bash
 docker compose logs standalone rustfs
 ```
-
 ### The bucket initializer fails
 
 Check RustFS readiness and the initializer logs:
@@ -331,7 +317,6 @@ Check RustFS readiness and the initializer logs:
 curl -fsS http://localhost:9000/health/ready
 docker compose logs create-bucket
 ```
-
 Verify that `.env` contains non-empty credentials and that `docker compose config` resolves both variables.
 
 ### Milvus starts without existing data
@@ -346,7 +331,6 @@ The Attu container must use `standalone:19530`. A browser or host-side client us
 curl -fsS http://localhost:9091/healthz
 docker compose logs attu standalone
 ```
-
 ## Next steps
 
 - Review [S3 compatibility notes](/administration/protocols/s3) before enabling additional Milvus storage features.

--- a/content/de/developer/integration/reverse-proxy/caddy.md
+++ b/content/de/developer/integration/reverse-proxy/caddy.md
@@ -26,7 +26,6 @@ Create a directory for the deployment:
 mkdir rustfs-caddy
 cd rustfs-caddy
 ```
-
 ## 2. Set deployment variables
 
 Create an environment file and replace each value:
@@ -38,7 +37,6 @@ ACME_EMAIL=admin@example.com
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Use an email address that receives certificate notices. Do not commit `.env` to source control.
 
 ## 3. Configure Caddy
@@ -72,7 +70,6 @@ Create a Caddyfile with one site block for each RustFS endpoint:
 		}
 }
 ```
-
 Caddy preserves the incoming `Host` header, HTTP method, and request URI by default. It also forwards client information through `X-Forwarded-*` headers and handles Console WebSocket upgrades without additional header rules.
 
 ## 4. Create the Compose file
@@ -112,7 +109,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -135,7 +132,6 @@ volumes:
 networks:
   rustfs:
 ```
-
 The persistent `caddy-data` volume stores certificates, private keys, and ACME account state. Back up this volume and do not share its contents. Only Caddy publishes host ports; RustFS remains reachable inside the Compose network.
 
 ## 5. Validate and start the deployment
@@ -146,13 +142,11 @@ Render the Compose configuration and start RustFS:
 docker compose config
 docker compose up -d rustfs
 ```
-
 Validate the Caddyfile with the same image used by the deployment:
 
 ```bash
 docker compose run --rm --no-deps caddy caddy validate --config /etc/caddy/Caddyfile
 ```
-
 Start Caddy and check both services:
 
 ```bash
@@ -160,7 +154,6 @@ docker compose up -d caddy
 docker compose ps
 docker compose logs --follow caddy
 ```
-
 Caddy obtains certificates in the background and redirects HTTP requests to HTTPS. If issuance fails, confirm that both DNS records resolve to this host, ports `80` and `443` are reachable, and the `caddy-data` volume is writable.
 
 ## 6. Verify both endpoints
@@ -171,7 +164,6 @@ Verify the API and Console through their public HTTPS hostnames:
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 Configure S3 clients with `https://s3.example.com` as the endpoint and enable path-style addressing. Open `https://console.example.com` to sign in to the Console.
 
 ## Multi-node upstreams
@@ -199,7 +191,6 @@ For a distributed RustFS deployment, list every node in the corresponding site b
 		}
 }
 ```
-
 Replace `<your-cookie-secret>` with a random secret shared by all Caddy instances. Console affinity keeps an in-progress OpenID Connect login on the RustFS node that created its `state`. Keep port `9000` open directly between RustFS nodes because internal node RPC uses the same listener.
 
 ## Next steps

--- a/content/de/developer/integration/reverse-proxy/haproxy.md
+++ b/content/de/developer/integration/reverse-proxy/haproxy.md
@@ -26,14 +26,12 @@ Create directories for the HAProxy configuration and TLS certificate:
 mkdir -p rustfs-haproxy/config rustfs-haproxy/certs
 cd rustfs-haproxy
 ```
-
 HAProxy expects the certificate chain and private key in one PEM file. Combine them in this order:
 
 ```bash
 cat fullchain.pem privkey.pem > certs/rustfs.pem
 chmod 600 certs/rustfs.pem
 ```
-
 The certificate must cover both public hostnames.
 
 ## 2. Set RustFS credentials
@@ -44,7 +42,6 @@ Create an environment file and replace both credential placeholders:
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Do not commit this file or the certificate private key to source control.
 
 ## 3. Configure HAProxy
@@ -95,7 +92,6 @@ backend rustfs_console
     http-check expect status 200
     server rustfs rustfs:9001 check inter 10s fall 3 rise 2 cookie rustfs
 ```
-
 HAProxy preserves the incoming host and request path unless you explicitly rewrite them. The long client, server, and tunnel timeouts accommodate streaming S3 operations and Console WebSocket connections.
 
 The Console backend sets an affinity cookie. With one RustFS server it has no routing effect, but keeping it in the base configuration makes the behavior consistent when you add nodes.
@@ -131,7 +127,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -152,7 +148,6 @@ volumes:
 networks:
   rustfs:
 ```
-
 Only HAProxy publishes host ports. RustFS ports `9000` and `9001` remain reachable inside the Compose network.
 
 ## 5. Validate and start the deployment
@@ -163,27 +158,23 @@ Render the Compose configuration and start RustFS:
 docker compose config
 docker compose up -d rustfs
 ```
-
 Validate the HAProxy configuration with the same image used by the deployment:
 
 ```bash
 docker compose run --rm --no-deps haproxy haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg
 ```
-
 Start HAProxy and check both services:
 
 ```bash
 docker compose up -d haproxy
 docker compose ps
 ```
-
 If a service does not become healthy, inspect its logs:
 
 ```bash
 docker compose logs haproxy
 docker compose logs rustfs
 ```
-
 ## 6. Verify both endpoints
 
 Verify the API and Console through their public HTTPS hostnames:
@@ -192,7 +183,6 @@ Verify the API and Console through their public HTTPS hostnames:
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 Configure S3 clients with `https://s3.example.com` as the endpoint and enable path-style addressing. Open `https://console.example.com` to sign in to the Console.
 
 When you replace a renewed `certs/rustfs.pem`, validate the configuration and recreate the HAProxy container to load it:
@@ -201,7 +191,6 @@ When you replace a renewed `certs/rustfs.pem`, validate the configuration and re
 docker compose run --rm --no-deps haproxy haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg
 docker compose up -d --force-recreate haproxy
 ```
-
 ## Multi-node backends
 
 For a distributed RustFS deployment, add every RustFS node to both backends:
@@ -226,7 +215,6 @@ backend rustfs_console
 		server node3 node3.example.net:9001 check inter 10s fall 3 rise 2 cookie node3
 		server node4 node4.example.net:9001 check inter 10s fall 3 rise 2 cookie node4
 ```
-
 The Console cookie keeps an in-progress OpenID Connect login on the RustFS node that created its `state`. Keep port `9000` open directly between RustFS nodes because internal node RPC uses the same listener.
 
 ## Next steps

--- a/content/de/developer/integration/reverse-proxy/nginx.md
+++ b/content/de/developer/integration/reverse-proxy/nginx.md
@@ -26,7 +26,6 @@ Create directories for the Nginx configuration and TLS certificate:
 mkdir -p rustfs-nginx/sites rustfs-nginx/certs
 cd rustfs-nginx
 ```
-
 Copy your certificate chain and private key into `certs/`:
 
 ```text
@@ -36,13 +35,11 @@ rustfs-nginx/
 │   └── privkey.pem
 └── sites/
 ```
-
 Restrict access to the private key:
 
 ```bash
 chmod 600 certs/privkey.pem
 ```
-
 ## 2. Set RustFS credentials
 
 Create an environment file and replace both credential placeholders:
@@ -51,7 +48,6 @@ Create an environment file and replace both credential placeholders:
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Do not commit this file to source control.
 
 ## 3. Configure Nginx
@@ -136,7 +132,6 @@ server {
     }
 }
 ```
-
 The S3 server preserves the original host and request path, disables request buffering for streaming uploads, and does not convert signed `HEAD` requests. The Console server also forwards WebSocket upgrade headers.
 
 ## 4. Create the Compose file
@@ -170,7 +165,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -191,7 +186,6 @@ volumes:
 networks:
   rustfs:
 ```
-
 Only Nginx publishes host ports. RustFS ports `9000` and `9001` remain reachable inside the Compose network.
 
 ## 5. Validate and start the deployment
@@ -203,21 +197,18 @@ docker compose config
 docker compose up -d rustfs
 docker compose run --rm --no-deps nginx nginx -t
 ```
-
 Start Nginx and check both services:
 
 ```bash
 docker compose up -d nginx
 docker compose ps
 ```
-
 If a service does not become healthy, inspect its logs:
 
 ```bash
 docker compose logs nginx
 docker compose logs rustfs
 ```
-
 ## 6. Verify both endpoints
 
 Verify the API and Console through their public HTTPS hostnames:
@@ -226,7 +217,6 @@ Verify the API and Console through their public HTTPS hostnames:
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 Configure S3 clients with `https://s3.example.com` as the endpoint and enable path-style addressing. Open `https://console.example.com` to sign in to the Console.
 
 When you replace a renewed certificate or key in `certs/`, validate and reload Nginx without interrupting active connections:
@@ -235,7 +225,6 @@ When you replace a renewed certificate or key in `certs/`, validate and reload N
 docker compose exec nginx nginx -t
 docker compose exec nginx nginx -s reload
 ```
-
 ## Multi-node upstreams
 
 For a distributed RustFS deployment, replace the single server in each upstream with all RustFS nodes:
@@ -259,7 +248,6 @@ upstream rustfs_console {
   keepalive 16;
 }
 ```
-
 The Console upstream uses client affinity because an in-progress OpenID Connect login stores its `state` on one RustFS node. Keep port `9000` open between RustFS nodes because internal node RPC uses the same listener.
 
 ## Next steps

--- a/content/de/developer/integration/reverse-proxy/traefik.md
+++ b/content/de/developer/integration/reverse-proxy/traefik.md
@@ -28,7 +28,6 @@ cd rustfs-traefik
 touch acme.json
 chmod 600 acme.json
 ```
-
 ## 2. Set deployment variables
 
 Create an environment file and replace each value:
@@ -40,7 +39,6 @@ ACME_EMAIL=admin@example.com
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Use an email address that receives certificate expiration notices. Do not commit `.env` or `acme.json` to source control.
 
 ## 3. Create the Compose file
@@ -86,7 +84,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -125,7 +123,6 @@ networks:
   rustfs:
     name: rustfs
 ```
-
 The two routers use different host rules and backend ports. RustFS does not publish ports `9000` or `9001` on the Docker host, and the Traefik Dashboard is not exposed.
 
 :::note[Docker socket access]
@@ -141,20 +138,17 @@ Render the Compose configuration and check that all variables resolve:
 ```bash
 docker compose config
 ```
-
 Start both services:
 
 ```bash
 docker compose up -d
 docker compose ps
 ```
-
 Follow the Traefik logs while it completes the ACME challenge and creates both certificates:
 
 ```bash
 docker compose logs --follow traefik
 ```
-
 If certificate issuance fails, confirm that both DNS records resolve to this host and that ports `80` and `443` are reachable from the internet. Let's Encrypt rate limits apply, so correct DNS and firewall problems before repeatedly recreating the deployment.
 
 ## 5. Verify both endpoints
@@ -165,7 +159,6 @@ Verify the S3 API readiness endpoint and Console health endpoint through Traefik
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 Configure S3 clients with `https://s3.example.com` as the endpoint and enable path-style addressing. Open `https://console.example.com` to sign in to the Console.
 
 ## Multi-node services
@@ -181,7 +174,6 @@ services:
     volumes:
       - ./dynamic.yaml:/etc/traefik/dynamic.yaml:ro
 ```
-
 Create the dynamic configuration with every RustFS node:
 
 ```yaml title="dynamic.yaml"
@@ -233,7 +225,6 @@ http:
           - url: http://node3.example.net:9001
           - url: http://node4.example.net:9001
 ```
-
 Configure sticky sessions for the Console service when you use OpenID Connect. An in-progress login stores its `state` on one RustFS node and the callback must return to that node. Keep port `9000` open directly between RustFS nodes because internal node RPC uses the same listener.
 
 ## Next steps

--- a/content/de/installation/container/docker.md
+++ b/content/de/installation/container/docker.md
@@ -17,6 +17,11 @@ Create a named volume so object data remains available when you replace the cont
 
 ```bash
 docker volume create rustfs-data
+docker volume create rustfs-logs
+
+# Bind-mount alternative (host directories must be owned by 10001:10001):
+# mkdir -p data logs
+# sudo chown -R 10001:10001 data logs
 ```
 
 ## 3. Start RustFS
@@ -30,13 +35,14 @@ docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v rustfs-data:/data \
+  -v rustfs-logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   rustfs/rustfs:latest \
   /data
 ```
@@ -55,7 +61,6 @@ Check the container and the S3 API health endpoint:
 docker ps --filter name=rustfs
 curl --fail http://localhost:9000/health
 ```
-
 The S3 API is available at `http://localhost:9000`, and the Console is available at `http://localhost:9001`.
 
 ## Next steps

--- a/content/de/installation/container/index.mdx
+++ b/content/de/installation/container/index.mdx
@@ -32,7 +32,6 @@ Pull the official image (Alpine-based) from Docker Hub:
 ```bash
 docker pull rustfs/rustfs
 ```
-
 ---
 
 
@@ -47,10 +46,10 @@ RustFS SNSD Docker running method, combining the above image and configuration, 
   -p 9000:9000 \
   -p 9001:9001 \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   rustfs/rustfs:latest \
   /data
 ```
-
 Parameter descriptions:
 
 * `-p 9000:9000`: Map host port 9000 to container
@@ -67,27 +66,6 @@ Configuration can be passed as environment variables (recommended) or as command
 <Tabs items={["Environment variables", "Command-line flags"]}>
   <Tab value="Environment variables" id="docker-env-config">
 
-```bash {7,8}
-# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
-docker run -d \
-  --name rustfs \
-  -p 9000:9000 \
-  -p 9001:9001 \
-  -v /mnt/rustfs/data:/data \
-  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
-  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
-  -e RUSTFS_ADDRESS=":9000" \
-  -e RUSTFS_CONSOLE_ADDRESS=":9001" \
-  -e RUSTFS_CONSOLE_ENABLE=true \
-  -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
-  rustfs/rustfs:latest \
-  /data
-```
-
-  </Tab>
-  <Tab value="Command-line flags" id="docker-cli-config">
-
 ```bash {8,9}
 # Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
 docker run -d \
@@ -95,6 +73,28 @@ docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
+  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
+  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
+  -e RUSTFS_ADDRESS=":9000" \
+  -e RUSTFS_CONSOLE_ADDRESS=":9001" \
+  -e RUSTFS_CONSOLE_ENABLE=true \
+  -e RUSTFS_OBS_LOGGER_LEVEL=error \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
+  rustfs/rustfs:latest \
+  /data
+```
+  </Tab>
+  <Tab value="Command-line flags" id="docker-cli-config">
+
+```bash {9,10}
+# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
+docker run -d \
+  --name rustfs \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   rustfs/rustfs:latest \
   --access-key "<your-access-key>" \
   --secret-key "<your-secret-key>" \
@@ -102,7 +102,6 @@ docker run -d \
   --console-enable \
   /data
 ```
-
   </Tab>
 </Tabs>
 
@@ -114,6 +113,7 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
      rustfs/rustfs:latest \
      /data
    ```
@@ -124,11 +124,12 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
     -e RUSTFS_ADDRESS=":9000" \
     -e RUSTFS_CONSOLE_ADDRESS=":9001" \
     -e RUSTFS_CONSOLE_ENABLE=true \
     -e RUSTFS_OBS_LOGGER_LEVEL=error \
-    -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+    -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
      rustfs/rustfs:latest \
      --console-enable \
      /data
@@ -141,6 +142,7 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
      -e RUSTFS_ACCESS_KEY="<your-access-key>" \
      -e RUSTFS_SECRET_KEY="<your-secret-key>" \
      rustfs/rustfs:latest \
@@ -173,13 +175,11 @@ RustFS officially provides a Docker Compose installation method. The [`docker-co
 ```bash
 git clone https://github.com/rustfs/rustfs.git
 ```
-
 Running the command under root directory,
 
 ```bash
 docker compose --profile observability up -d
 ```
-
 Providing the necessary permissions. An initialization container is necessary to grant the correct access rights to rustfs using the `depends_on` keyword. In the example below the `rustfs_perms` service is added to the `docker-compose.yml` to handle this. To ensure logs are persisted and accessible, we map the host log directory to the container's `/var/log/rustfs/` path
 
 ```yaml title="docker-compose.yml"
@@ -199,17 +199,16 @@ Providing the necessary permissions. An initialization container is necessary to
           condition: service_completed_successfully
       volumes:
         - /path/to_host_directory/volumes/data:/data
-        - /path/to_host_directory/volumes/logs:/var/log/rustfs/
+        - /path/to_host_directory/volumes/logs:/logs
       environment:
         - RUSTFS_ADDRESS=":9000"
         - RUSTFS_CONSOLE_ADDRESS=":9001"
         - RUSTFS_CONSOLE_ENABLE=true
         - RUSTFS_OBS_LOGGER_LEVEL=error
-        - RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/"
+        - RUSTFS_OBS_LOG_DIRECTORY="/logs"
     
       # ... other configurations
 ```
-
 Started containers is as below,
 
 ```text
@@ -220,13 +219,11 @@ e3f4fc4a83a2   grafana/grafana:latest                            "/run.sh"      
 e7db806b2d6f   jaegertracing/all-in-one:latest                   "/go/bin/all-in-one-…"   7 seconds ago   Up 5 seconds                      4317-4318/tcp, 9411/tcp, 0.0.0.0:14250->14250/tcp, :::14250->14250/tcp, 14268/tcp, 0.0.0.0:16686->16686/tcp, :::16686->16686/tcp          jaeger
 1897830a2f1e   otel/opentelemetry-collector-contrib:latest       "/otelcol-contrib --…"   7 seconds ago   Up 5 seconds                      0.0.0.0:4317-4318->4317-4318/tcp, :::4317-4318->4317-4318/tcp, 0.0.0.0:8888-8889->8888-8889/tcp, :::8888-8889->8888-8889/tcp, 55679/tcp   otel-collector
 ```
-
 If you only want to install RustFS without Grafana, Prometheus, and the other observability services, start just the `rustfs` service (the compose file marks the collector dependency as optional):
 
 ```bash
 docker compose -f docker-compose.yml up -d rustfs
 ```
-
 This way will only install and start `rustfs-server` service, namely rustfs container,
 
 ```text
@@ -234,7 +231,6 @@ docker ps
 CONTAINER ID   IMAGE                                             COMMAND                  CREATED         STATUS                           PORTS                                                           NAMES
 e07121ecdd39   rustfs/rustfs:latest                              "/entrypoint.sh rust…"   2 seconds ago   Up 1 second (health: starting)   0.0.0.0:9000-9001->9000-9001/tcp, :::9000-9001->9000-9001/tcp   rustfs-server
 ```
-
 Whether you start only the `rustfs-server` or together with observability services, the S3 API is served at `http://localhost:9000`, and the RustFS Console is at `http://localhost:9001` — open it in a browser and log in with the access key and secret key you configured above (the `<your-access-key>` / `<your-secret-key>` placeholders). Generate a strong secret with, for example, `openssl rand -base64 24`, and never ship the placeholder values to production.
 
 :::warning[Set container credentials immediately]
@@ -278,17 +274,17 @@ docker run -d \
   --name rustfs \
   --network host \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   -e RUSTFS_VOLUMES="http://node{1...4}:9000/data/rustfs{0...3}" \
   rustfs/rustfs:latest
 ```
-
 Add the entries to `/etc/hosts` on **every** node:
 ```ini title="/etc/hosts"
 192.168.1.1 node1
@@ -296,7 +292,6 @@ Add the entries to `/etc/hosts` on **every** node:
 192.168.1.3 node3
 192.168.1.4 node4
 ```
-
 ## 6. Other Recommendations
 
 1. Production Environment Recommendations:

--- a/content/de/installation/container/podman.md
+++ b/content/de/installation/container/podman.md
@@ -17,6 +17,11 @@ Create a named volume so object data remains available when you replace the cont
 
 ```bash
 podman volume create rustfs-data
+podman volume create rustfs-logs
+
+# Bind-mount alternative on SELinux hosts (`:U` sets ownership; `:Z` sets the SELinux label):
+# mkdir -p data logs
+# podman run ... -v "$(pwd)/data":/data:Z,U -v "$(pwd)/logs":/logs:Z,U ...
 ```
 
 ## 3. Start RustFS
@@ -29,13 +34,14 @@ podman run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v rustfs-data:/data \
+  -v rustfs-logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   docker.io/rustfs/rustfs:latest \
   /data
 ```
@@ -54,7 +60,6 @@ Check the container and the S3 API health endpoint:
 podman ps --filter name=rustfs
 curl --fail http://localhost:9000/health
 ```
-
 The S3 API is available at `http://localhost:9000`, and the Console is available at `http://localhost:9001`.
 
 ## Next steps

--- a/content/de/operations/observability.md
+++ b/content/de/operations/observability.md
@@ -12,14 +12,12 @@ RustFS (RUSTFS_OBS_ENDPOINT) --OTLP--> OpenTelemetry Collector --> Prometheus --
                                                               \--> Loki (logs)
                                                               \--> Tempo / Jaeger (traces)
 ```
-
 Point RustFS at the Collector with:
 
 ```bash
 # OTLP over HTTP (the Collector's default HTTP receiver port is 4318; gRPC is 4317)
 RUSTFS_OBS_ENDPOINT=http://otel-collector:4318
 ```
-
 Related environment variables (all defined in the server configuration):
 
 | Variable | Purpose |
@@ -53,7 +51,6 @@ service:
       receivers: [otlp]
       exporters: [prometheus]
 ```
-
 Prometheus then scrapes the Collector, not RustFS:
 
 ```yaml
@@ -66,7 +63,6 @@ scrape_configs:
     static_configs:
       - targets: ["otel-collector:8888"]   # Collector self-metrics
 ```
-
 :::note
 
 If Prometheus shows no `rustfs_*` series, check the chain in order: is `RUSTFS_OBS_ENDPOINT` set on every node, is the Collector reachable from the nodes, and is Prometheus scraping the Collector's `8889` exporter port.
@@ -219,6 +215,7 @@ RUSTFS_ADDRESS=":9000"
 RUSTFS_CONSOLE_ADDRESS=":9001"
 RUSTFS_CONSOLE_ENABLE=true
 RUSTFS_OBS_LOGGER_LEVEL=error
+# Linux packages use /var/log/rustfs/; the container image uses /logs.
 RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/"
 RUSTFS_OBS_ENDPOINT=http://otel-collector:4318
 ```

--- a/content/de/operations/upgrade/container/index.md
+++ b/content/de/operations/upgrade/container/index.md
@@ -28,17 +28,16 @@ The following workflow matches the container name and named volume used in the [
 Record the current image, then pull the target version:
 
 ```bash
+docker volume create rustfs-logs
 docker inspect --format '{{.Config.Image}}' rustfs
 docker pull rustfs/rustfs:<target-version>
 ```
-
 Stop and remove only the container. The `rustfs-data` volume remains intact:
 
 ```bash
 docker stop rustfs
 docker rm rustfs
 ```
-
 Recreate the container with the original configuration and the target image:
 
 ```bash
@@ -48,17 +47,17 @@ docker run -d \
 	-p 9000:9000 \
 	-p 9001:9001 \
 	-v rustfs-data:/data \
+	-v rustfs-logs:/logs \
 	-e RUSTFS_ACCESS_KEY="<your-access-key>" \
 	-e RUSTFS_SECRET_KEY="<your-secret-key>" \
 	-e RUSTFS_ADDRESS=":9000" \
 	-e RUSTFS_CONSOLE_ADDRESS=":9001" \
 	-e RUSTFS_CONSOLE_ENABLE=true \
 	-e RUSTFS_OBS_LOGGER_LEVEL=error \
-	-e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+	-e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
 	rustfs/rustfs:<target-version> \
 	/data
 ```
-
 Wait for the replacement container to become healthy:
 
 ```bash
@@ -72,12 +71,12 @@ curl -fsS http://localhost:9000/health/ready
 The Podman workflow is the same replacement operation, using the image name from the [Podman installation guide](/installation/container/podman).
 
 ```bash
+podman volume create rustfs-logs
 podman inspect --format '{{.Config.Image}}' rustfs
 podman pull docker.io/rustfs/rustfs:<target-version>
 podman stop rustfs
 podman rm rustfs
 ```
-
 Recreate the container with the original configuration and persistent volume:
 
 ```bash
@@ -86,17 +85,17 @@ podman run -d \
 	-p 9000:9000 \
 	-p 9001:9001 \
 	-v rustfs-data:/data \
+	-v rustfs-logs:/logs \
 	-e RUSTFS_ACCESS_KEY="<your-access-key>" \
 	-e RUSTFS_SECRET_KEY="<your-secret-key>" \
 	-e RUSTFS_ADDRESS=":9000" \
 	-e RUSTFS_CONSOLE_ADDRESS=":9001" \
 	-e RUSTFS_CONSOLE_ENABLE=true \
 	-e RUSTFS_OBS_LOGGER_LEVEL=error \
-	-e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+	-e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
 	docker.io/rustfs/rustfs:<target-version> \
 	/data
 ```
-
 Verify the replacement before continuing:
 
 ```bash
@@ -113,7 +112,6 @@ Run Compose commands from the directory containing the deployment's `docker-comp
 docker compose config > docker-compose.resolved.yaml
 docker compose images rustfs
 ```
-
 Change the `rustfs` service to an explicit target image tag while leaving its volumes, environment, ports, and command unchanged:
 
 ```yaml title="docker-compose.yml"
@@ -121,7 +119,6 @@ services:
 	rustfs:
 		image: rustfs/rustfs:<target-version>
 ```
-
 Validate the file, pull the target image, and recreate only the RustFS service. `--no-deps` leaves optional observability services running:
 
 ```bash
@@ -129,7 +126,6 @@ docker compose config --quiet
 docker compose pull rustfs
 docker compose up -d --no-deps rustfs
 ```
-
 Check the service and the RustFS readiness endpoint:
 
 ```bash
@@ -137,7 +133,6 @@ docker compose ps rustfs
 docker compose logs --tail=100 rustfs
 curl -fsS http://localhost:9000/health/ready
 ```
-
 If you started RustFS together with the `observability` profile, the RustFS service still upgrades with the same commands. Upgrade observability images separately according to each component's release notes.
 
 ## Upgrade a multi-node deployment
@@ -157,7 +152,6 @@ docker compose pull rustfs
 docker compose up -d --no-deps rustfs
 curl -fsS http://localhost:9000/health/ready
 ```
-
 In a multi-node deployment, roll back one node at a time and wait for readiness before continuing.
 
 ## Next steps

--- a/content/en/developer/integration/big-data/iceberg.md
+++ b/content/en/developer/integration/big-data/iceberg.md
@@ -74,7 +74,7 @@ services:
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     volumes:
       - rustfs-data:/data
     ports:

--- a/content/en/developer/integration/big-data/milvus.md
+++ b/content/en/developer/integration/big-data/milvus.md
@@ -100,7 +100,7 @@ services:
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     volumes:
       - rustfs-data:/data
     ports:

--- a/content/en/developer/integration/reverse-proxy/caddy.md
+++ b/content/en/developer/integration/reverse-proxy/caddy.md
@@ -112,7 +112,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"

--- a/content/en/developer/integration/reverse-proxy/haproxy.md
+++ b/content/en/developer/integration/reverse-proxy/haproxy.md
@@ -131,7 +131,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"

--- a/content/en/developer/integration/reverse-proxy/nginx.md
+++ b/content/en/developer/integration/reverse-proxy/nginx.md
@@ -170,7 +170,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"

--- a/content/en/developer/integration/reverse-proxy/traefik.md
+++ b/content/en/developer/integration/reverse-proxy/traefik.md
@@ -86,7 +86,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"

--- a/content/en/installation/container/docker.md
+++ b/content/en/installation/container/docker.md
@@ -20,22 +20,13 @@ Create named volumes so object data and logs remain available when you replace t
 ```bash
 docker volume create rustfs-data
 docker volume create rustfs-logs
+
+# Bind-mount alternative (host directories must be owned by 10001:10001):
+# mkdir -p data logs
+# sudo chown -R 10001:10001 data logs
 ```
 
-Named volumes mounted at `/data` and `/logs` inherit the image's `10001:10001` ownership.
-
-:::warning[Bind mounts need UID 10001]
-
-If you bind-mount host directories instead of named volumes, create them first and change their owner. Every bind-mounted path (data, logs, and TLS certificates when `RUSTFS_TLS_PATH` is set) must be writable by `10001:10001`:
-
-```bash
-mkdir -p data logs
-sudo chown -R 10001:10001 data logs
-```
-
-Then mount those directories at `/data` and `/logs`.
-
-:::
+Named volumes mounted at `/data` and `/logs` inherit the image's `10001:10001` ownership. If you bind-mount host directories instead, create them first and change their owner (`mkdir -p data logs` then `sudo chown -R 10001:10001 data logs`). Every bind-mounted path (data, logs, and TLS certificates when `RUSTFS_TLS_PATH` is set) must be writable by `10001:10001`.
 
 ## 3. Start RustFS
 

--- a/content/en/installation/container/docker.md
+++ b/content/en/installation/container/docker.md
@@ -5,6 +5,8 @@ description: "Run a single-node RustFS instance with Docker and persistent conta
 
 Use the official RustFS image to start a single-node instance with persistent storage. You need a working Docker Engine and permission to run containers.
 
+The image runs as the non-root user `rustfs` (`10001:10001`) and writes logs to `/logs` by default. Do not set `RUSTFS_OBS_LOG_DIRECTORY` to `/var/log/rustfs/`: that path is for Linux package installs, and the container user cannot create it.
+
 ## 1. Pull the image
 
 ```bash
@@ -13,11 +15,27 @@ docker pull rustfs/rustfs:latest
 
 ## 2. Create persistent storage
 
-Create a named volume so object data remains available when you replace the container:
+Create named volumes so object data and logs remain available when you replace the container:
 
 ```bash
 docker volume create rustfs-data
+docker volume create rustfs-logs
 ```
+
+Named volumes mounted at `/data` and `/logs` inherit the image's `10001:10001` ownership.
+
+:::warning[Bind mounts need UID 10001]
+
+If you bind-mount host directories instead of named volumes, create them first and change their owner. Every bind-mounted path (data, logs, and TLS certificates when `RUSTFS_TLS_PATH` is set) must be writable by `10001:10001`:
+
+```bash
+mkdir -p data logs
+sudo chown -R 10001:10001 data logs
+```
+
+Then mount those directories at `/data` and `/logs`.
+
+:::
 
 ## 3. Start RustFS
 
@@ -30,20 +48,21 @@ docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v rustfs-data:/data \
+  -v rustfs-logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   rustfs/rustfs:latest \
   /data
 ```
 
 :::warning[Set credentials when creating the container]
 
-Set unique `RUSTFS_ACCESS_KEY` and `RUSTFS_SECRET_KEY` environment variables before exposing RustFS to a network. Do not use the well-known `rustfsadmin` value for either credential. If the container was started without custom credentials, stop and recreate it with both `-e` options shown above; the `rustfs-data` volume remains intact.
+Set unique `RUSTFS_ACCESS_KEY` and `RUSTFS_SECRET_KEY` environment variables before exposing RustFS to a network. Do not use the well-known `rustfsadmin` value for either credential. If the container was started without custom credentials, stop and recreate it with both `-e` options shown above; the `rustfs-data` and `rustfs-logs` volumes remain intact.
 
 :::
 

--- a/content/en/installation/container/index.mdx
+++ b/content/en/installation/container/index.mdx
@@ -22,12 +22,7 @@ This article is based on RustFS official Linux binary packages, packaging RustFS
 3. **Directory Permissions**
 
  * The RustFS container runs as non-root user `rustfs` (`10001:10001`). The image owns `/data` and `/logs`, and the image default for `RUSTFS_OBS_LOG_DIRECTORY` is `/logs`. Do not set that variable to `/var/log/rustfs/` — the container user cannot create that path.
- * If you bind-mount host directories with `-v`, every mounted path (data, logs, and TLS certificates) must be owned by `10001:10001`:
-
-```bash
-sudo mkdir -p /mnt/rustfs/data /mnt/rustfs/logs
-sudo chown -R 10001:10001 /mnt/rustfs/data /mnt/rustfs/logs
-```
+ * If you bind-mount host directories with `-v`, every mounted path (data, logs, and TLS certificates) must be owned by `10001:10001`. Run `sudo mkdir -p /mnt/rustfs/data /mnt/rustfs/logs` and `sudo chown -R 10001:10001 /mnt/rustfs/data /mnt/rustfs/logs` before starting the container.
 
 ---
 
@@ -172,11 +167,7 @@ docker run -d \
 
 3. Environment variables and command line parameters can be mixed, but command line parameters have higher priority
 
-4. If [using TLS](../../integration/tls-configured.md), additional certificate path mounting is needed. The certificate directory must also be readable by UID `10001`:
-
-   ```bash
-   sudo chown -R 10001:10001 /path/to/certs
-   ```
+4. If [using TLS](../../integration/tls-configured.md), additional certificate path mounting is needed. The certificate directory must also be readable by UID `10001` (`sudo chown -R 10001:10001 /path/to/certs`):
 
    ```bash
    -v /path/to/certs:/certs \

--- a/content/en/installation/container/index.mdx
+++ b/content/en/installation/container/index.mdx
@@ -13,7 +13,7 @@ This article is based on RustFS official Linux binary packages, packaging RustFS
 1. **Host Requirements**
 
  * Docker installed (≥ 20.10) and able to pull images and run containers normally
- * Local path `/mnt/rustfs/data` (or custom path) for mounting object data
+ * Local paths `/mnt/rustfs/data` and `/mnt/rustfs/logs` (or custom paths) for mounting object data and logs
  * [`rc`](/operations/rc) installed on the administration host for the verification workflow
 2. **Network and Firewall**
 
@@ -21,7 +21,13 @@ This article is based on RustFS official Linux binary packages, packaging RustFS
 
 3. **Directory Permissions**
 
- * The RustFS container runs as non-root user `rustfs` with id `10001`. If you run docker with `-v` to mount a host directory into the container, make sure the owner of the host directory is `10001`, otherwise you will encounter permission denied errors. Run `chown -R 10001:10001 /path/to/host_directory` to grant the necessary permissions.
+ * The RustFS container runs as non-root user `rustfs` (`10001:10001`). The image owns `/data` and `/logs`, and the image default for `RUSTFS_OBS_LOG_DIRECTORY` is `/logs`. Do not set that variable to `/var/log/rustfs/` — the container user cannot create that path.
+ * If you bind-mount host directories with `-v`, every mounted path (data, logs, and TLS certificates) must be owned by `10001:10001`:
+
+```bash
+sudo mkdir -p /mnt/rustfs/data /mnt/rustfs/logs
+sudo chown -R 10001:10001 /mnt/rustfs/data /mnt/rustfs/logs
+```
 
 ---
 
@@ -47,6 +53,7 @@ RustFS SNSD Docker running method, combining the above image and configuration, 
   -p 9000:9000 \
   -p 9001:9001 \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   rustfs/rustfs:latest \
   /data
 ```
@@ -54,7 +61,8 @@ RustFS SNSD Docker running method, combining the above image and configuration, 
 Parameter descriptions:
 
 * `-p 9000:9000`: Map host port 9000 to container
-* `-v /mnt/rustfs/data:/data`: Mount data volume
+* `-v /mnt/rustfs/data:/data`: Mount the data directory
+* `-v /mnt/rustfs/logs:/logs`: Mount the log directory (image default; writable by UID `10001`)
 * `--name rustfs_local`: Custom container name
 * `-d`: Run in background
 
@@ -67,27 +75,6 @@ Configuration can be passed as environment variables (recommended) or as command
 <Tabs items={["Environment variables", "Command-line flags"]}>
   <Tab value="Environment variables" id="docker-env-config">
 
-```bash {7,8}
-# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
-docker run -d \
-  --name rustfs \
-  -p 9000:9000 \
-  -p 9001:9001 \
-  -v /mnt/rustfs/data:/data \
-  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
-  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
-  -e RUSTFS_ADDRESS=":9000" \
-  -e RUSTFS_CONSOLE_ADDRESS=":9001" \
-  -e RUSTFS_CONSOLE_ENABLE=true \
-  -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
-  rustfs/rustfs:latest \
-  /data
-```
-
-  </Tab>
-  <Tab value="Command-line flags" id="docker-cli-config">
-
 ```bash {8,9}
 # Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
 docker run -d \
@@ -95,6 +82,29 @@ docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
+  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
+  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
+  -e RUSTFS_ADDRESS=":9000" \
+  -e RUSTFS_CONSOLE_ADDRESS=":9001" \
+  -e RUSTFS_CONSOLE_ENABLE=true \
+  -e RUSTFS_OBS_LOGGER_LEVEL=error \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
+  rustfs/rustfs:latest \
+  /data
+```
+
+  </Tab>
+  <Tab value="Command-line flags" id="docker-cli-config">
+
+```bash {9,10}
+# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
+docker run -d \
+  --name rustfs \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   rustfs/rustfs:latest \
   --access-key "<your-access-key>" \
   --secret-key "<your-secret-key>" \
@@ -114,6 +124,7 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
      rustfs/rustfs:latest \
      /data
    ```
@@ -124,11 +135,12 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
     -e RUSTFS_ADDRESS=":9000" \
     -e RUSTFS_CONSOLE_ADDRESS=":9001" \
     -e RUSTFS_CONSOLE_ENABLE=true \
     -e RUSTFS_OBS_LOGGER_LEVEL=error \
-    -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+    -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
      rustfs/rustfs:latest \
      --console-enable \
      /data
@@ -141,6 +153,7 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
      -e RUSTFS_ACCESS_KEY="<your-access-key>" \
      -e RUSTFS_SECRET_KEY="<your-secret-key>" \
      rustfs/rustfs:latest \
@@ -159,7 +172,11 @@ docker run -d \
 
 3. Environment variables and command line parameters can be mixed, but command line parameters have higher priority
 
-4. If [using TLS](../../integration/tls-configured.md), additional certificate path mounting is needed:
+4. If [using TLS](../../integration/tls-configured.md), additional certificate path mounting is needed. The certificate directory must also be readable by UID `10001`:
+
+   ```bash
+   sudo chown -R 10001:10001 /path/to/certs
+   ```
 
    ```bash
    -v /path/to/certs:/certs \
@@ -180,7 +197,7 @@ Running the command under root directory,
 docker compose --profile observability up -d
 ```
 
-Providing the necessary permissions. An initialization container is necessary to grant the correct access rights to rustfs using the `depends_on` keyword. In the example below the `rustfs_perms` service is added to the `docker-compose.yml` to handle this. To ensure logs are persisted and accessible, we map the host log directory to the container's `/var/log/rustfs/` path
+Providing the necessary permissions. An initialization container is necessary to grant the correct access rights to rustfs using the `depends_on` keyword. In the example below the `rustfs_perms` service is added to the `docker-compose.yml` to handle this. To persist logs, map the host log directory to the container's `/logs` path (the image default). Do not mount or set `RUSTFS_OBS_LOG_DIRECTORY` to `/var/log/rustfs/`.
 
 ```yaml title="docker-compose.yml"
   services:
@@ -199,13 +216,13 @@ Providing the necessary permissions. An initialization container is necessary to
           condition: service_completed_successfully
       volumes:
         - /path/to_host_directory/volumes/data:/data
-        - /path/to_host_directory/volumes/logs:/var/log/rustfs/
+        - /path/to_host_directory/volumes/logs:/logs
       environment:
         - RUSTFS_ADDRESS=":9000"
         - RUSTFS_CONSOLE_ADDRESS=":9001"
         - RUSTFS_CONSOLE_ENABLE=true
         - RUSTFS_OBS_LOGGER_LEVEL=error
-        - RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/"
+        - RUSTFS_OBS_LOG_DIRECTORY="/logs"
     
       # ... other configurations
 ```
@@ -278,13 +295,14 @@ docker run -d \
   --name rustfs \
   --network host \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   -e RUSTFS_VOLUMES="http://node{1...4}:9000/data/rustfs{0...3}" \
   rustfs/rustfs:latest
 ```

--- a/content/en/installation/container/podman.md
+++ b/content/en/installation/container/podman.md
@@ -5,6 +5,8 @@ description: "Run a single-node RustFS instance with Podman and persistent conta
 
 Podman can run the official RustFS Open Container Initiative (OCI) image without a daemon. You need a working Podman installation and permission to create containers.
 
+The image runs as the non-root user `rustfs` (`10001:10001`) and writes logs to `/logs` by default. Do not set `RUSTFS_OBS_LOG_DIRECTORY` to `/var/log/rustfs/`: that path is for Linux package installs, and the container user cannot create it.
+
 ## 1. Pull the image
 
 ```bash
@@ -13,11 +15,36 @@ podman pull docker.io/rustfs/rustfs:latest
 
 ## 2. Create persistent storage
 
-Create a named volume so object data remains available when you replace the container:
+Create named volumes so object data and logs remain available when you replace the container:
 
 ```bash
 podman volume create rustfs-data
+podman volume create rustfs-logs
 ```
+
+Named volumes mounted at `/data` and `/logs` inherit the image's `10001:10001` ownership.
+
+:::warning[Bind mounts need UID 10001]
+
+If you bind-mount host directories instead of named volumes, create them first. Podman can adjust ownership with the `:U` mount option; `:Z` is required on SELinux hosts:
+
+```bash
+mkdir -p data logs
+podman run -d \
+  --name rustfs \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -v "$(pwd)/data":/data:Z,U \
+  -v "$(pwd)/logs":/logs:Z,U \
+  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
+  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
+  docker.io/rustfs/rustfs:latest \
+  /data
+```
+
+If you do not use `:U`, run `sudo chown -R 10001:10001 data logs` before starting the container. Every bind-mounted path (data, logs, and TLS certificates when `RUSTFS_TLS_PATH` is set) must be writable by `10001:10001`.
+
+:::
 
 ## 3. Start RustFS
 
@@ -29,20 +56,21 @@ podman run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v rustfs-data:/data \
+  -v rustfs-logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   docker.io/rustfs/rustfs:latest \
   /data
 ```
 
 :::warning[Set credentials when creating the container]
 
-Set unique `RUSTFS_ACCESS_KEY` and `RUSTFS_SECRET_KEY` environment variables before exposing RustFS to a network. Do not use the well-known `rustfsadmin` value for either credential. If the container was started without custom credentials, stop and recreate it with both `-e` options shown above; the `rustfs-data` volume remains intact.
+Set unique `RUSTFS_ACCESS_KEY` and `RUSTFS_SECRET_KEY` environment variables before exposing RustFS to a network. Do not use the well-known `rustfsadmin` value for either credential. If the container was started without custom credentials, stop and recreate it with both `-e` options shown above; the `rustfs-data` and `rustfs-logs` volumes remain intact.
 
 :::
 

--- a/content/en/installation/container/podman.md
+++ b/content/en/installation/container/podman.md
@@ -20,31 +20,13 @@ Create named volumes so object data and logs remain available when you replace t
 ```bash
 podman volume create rustfs-data
 podman volume create rustfs-logs
+
+# Bind-mount alternative on SELinux hosts (`:U` sets ownership; `:Z` sets the SELinux label):
+# mkdir -p data logs
+# podman run ... -v "$(pwd)/data":/data:Z,U -v "$(pwd)/logs":/logs:Z,U ...
 ```
 
-Named volumes mounted at `/data` and `/logs` inherit the image's `10001:10001` ownership.
-
-:::warning[Bind mounts need UID 10001]
-
-If you bind-mount host directories instead of named volumes, create them first. Podman can adjust ownership with the `:U` mount option; `:Z` is required on SELinux hosts:
-
-```bash
-mkdir -p data logs
-podman run -d \
-  --name rustfs \
-  -p 9000:9000 \
-  -p 9001:9001 \
-  -v "$(pwd)/data":/data:Z,U \
-  -v "$(pwd)/logs":/logs:Z,U \
-  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
-  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
-  docker.io/rustfs/rustfs:latest \
-  /data
-```
-
-If you do not use `:U`, run `sudo chown -R 10001:10001 data logs` before starting the container. Every bind-mounted path (data, logs, and TLS certificates when `RUSTFS_TLS_PATH` is set) must be writable by `10001:10001`.
-
-:::
+Named volumes mounted at `/data` and `/logs` inherit the image's `10001:10001` ownership. If you bind-mount host directories and do not use `:U`, run `sudo chown -R 10001:10001 data logs` first. Every bind-mounted path (data, logs, and TLS certificates when `RUSTFS_TLS_PATH` is set) must be writable by `10001:10001`.
 
 ## 3. Start RustFS
 

--- a/content/en/operations/observability.md
+++ b/content/en/operations/observability.md
@@ -209,7 +209,7 @@ Per-disk usage and disk online/offline state are currently surfaced through the 
 Where logs go is controlled by `RUSTFS_OBS_LOG_DIRECTORY`:
 
 - **Unset** — logs go to stdout. In containers, use your log driver; on systemd hosts, stdout/stderr is captured by **journald**, so `journalctl -u rustfs -f` works without extra configuration.
-- **A local directory** (e.g. `/var/log/rustfs/`) — RustFS writes rotating log files there. Rotation is tuned with `RUSTFS_OBS_LOG_FILENAME`, `RUSTFS_OBS_LOG_ROTATION_SIZE_MB`, `RUSTFS_OBS_LOG_ROTATION_TIME`, and `RUSTFS_OBS_LOG_KEEP_FILES`.
+- **A local directory** (e.g. `/var/log/rustfs/` on Linux packages, or `/logs` in the official container image) — RustFS writes rotating log files there. Rotation is tuned with `RUSTFS_OBS_LOG_FILENAME`, `RUSTFS_OBS_LOG_ROTATION_SIZE_MB`, `RUSTFS_OBS_LOG_ROTATION_TIME`, and `RUSTFS_OBS_LOG_KEEP_FILES`. The container process runs as UID `10001` and cannot create `/var/log/rustfs/`.
 - **A URL** (contains `://`) — logs are shipped to a remote endpoint.
 
 When `RUSTFS_OBS_ENDPOINT` is set and log export is enabled, logs are additionally exported via OTLP; the reference stack routes them into Loki for querying from Grafana.
@@ -219,6 +219,7 @@ RUSTFS_ADDRESS=":9000"
 RUSTFS_CONSOLE_ADDRESS=":9001"
 RUSTFS_CONSOLE_ENABLE=true
 RUSTFS_OBS_LOGGER_LEVEL=error
+# Linux packages use /var/log/rustfs/; the container image uses /logs.
 RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/"
 RUSTFS_OBS_ENDPOINT=http://otel-collector:4318
 ```

--- a/content/en/operations/upgrade/container/index.md
+++ b/content/en/operations/upgrade/container/index.md
@@ -17,13 +17,17 @@ curl -fsS http://localhost:9000/health/ready
 
 :::warning[Preserve persistent storage]
 
-Do not remove the named volume or host directory mounted at `/data`. Commands such as `docker compose down -v`, `docker volume rm`, and `podman volume rm` delete persistent storage and are not part of an upgrade.
+Do not remove the named volume or host directory mounted at `/data` (or `/logs`, if you persist container logs). Commands such as `docker compose down -v`, `docker volume rm`, and `podman volume rm` delete persistent storage and are not part of an upgrade.
 
 :::
 
 ## Upgrade a Docker container
 
-The following workflow matches the container name and named volume used in the [Docker installation guide](/installation/container/docker). If your deployment uses different ports, environment variables, mounts, or startup arguments, keep those settings unchanged in the replacement command.
+The following workflow matches the container name and named volumes used in the [Docker installation guide](/installation/container/docker). If your deployment uses different ports, environment variables, mounts, or startup arguments, keep those settings unchanged in the replacement command. If the original container did not mount `/logs`, create the log volume before recreating it:
+
+```bash
+docker volume create rustfs-logs
+```
 
 Record the current image, then pull the target version:
 
@@ -32,7 +36,7 @@ docker inspect --format '{{.Config.Image}}' rustfs
 docker pull rustfs/rustfs:<target-version>
 ```
 
-Stop and remove only the container. The `rustfs-data` volume remains intact:
+Stop and remove only the container. The `rustfs-data` and `rustfs-logs` volumes remain intact:
 
 ```bash
 docker stop rustfs
@@ -48,13 +52,14 @@ docker run -d \
 	-p 9000:9000 \
 	-p 9001:9001 \
 	-v rustfs-data:/data \
+	-v rustfs-logs:/logs \
 	-e RUSTFS_ACCESS_KEY="<your-access-key>" \
 	-e RUSTFS_SECRET_KEY="<your-secret-key>" \
 	-e RUSTFS_ADDRESS=":9000" \
 	-e RUSTFS_CONSOLE_ADDRESS=":9001" \
 	-e RUSTFS_CONSOLE_ENABLE=true \
 	-e RUSTFS_OBS_LOGGER_LEVEL=error \
-	-e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+	-e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
 	rustfs/rustfs:<target-version> \
 	/data
 ```
@@ -69,7 +74,11 @@ curl -fsS http://localhost:9000/health/ready
 
 ## Upgrade a Podman container
 
-The Podman workflow is the same replacement operation, using the image name from the [Podman installation guide](/installation/container/podman).
+The Podman workflow is the same replacement operation, using the image name from the [Podman installation guide](/installation/container/podman). If the original container did not mount `/logs`, create the log volume first:
+
+```bash
+podman volume create rustfs-logs
+```
 
 ```bash
 podman inspect --format '{{.Config.Image}}' rustfs
@@ -86,13 +95,14 @@ podman run -d \
 	-p 9000:9000 \
 	-p 9001:9001 \
 	-v rustfs-data:/data \
+	-v rustfs-logs:/logs \
 	-e RUSTFS_ACCESS_KEY="<your-access-key>" \
 	-e RUSTFS_SECRET_KEY="<your-secret-key>" \
 	-e RUSTFS_ADDRESS=":9000" \
 	-e RUSTFS_CONSOLE_ADDRESS=":9001" \
 	-e RUSTFS_CONSOLE_ENABLE=true \
 	-e RUSTFS_OBS_LOGGER_LEVEL=error \
-	-e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+	-e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
 	docker.io/rustfs/rustfs:<target-version> \
 	/data
 ```

--- a/content/en/operations/upgrade/container/index.md
+++ b/content/en/operations/upgrade/container/index.md
@@ -23,15 +23,12 @@ Do not remove the named volume or host directory mounted at `/data` (or `/logs`,
 
 ## Upgrade a Docker container
 
-The following workflow matches the container name and named volumes used in the [Docker installation guide](/installation/container/docker). If your deployment uses different ports, environment variables, mounts, or startup arguments, keep those settings unchanged in the replacement command. If the original container did not mount `/logs`, create the log volume before recreating it:
-
-```bash
-docker volume create rustfs-logs
-```
+The following workflow matches the container name and named volumes used in the [Docker installation guide](/installation/container/docker). If your deployment uses different ports, environment variables, mounts, or startup arguments, keep those settings unchanged in the replacement command. If the original container did not mount `/logs`, include `docker volume create rustfs-logs` before recreating the container.
 
 Record the current image, then pull the target version:
 
 ```bash
+docker volume create rustfs-logs
 docker inspect --format '{{.Config.Image}}' rustfs
 docker pull rustfs/rustfs:<target-version>
 ```
@@ -74,13 +71,10 @@ curl -fsS http://localhost:9000/health/ready
 
 ## Upgrade a Podman container
 
-The Podman workflow is the same replacement operation, using the image name from the [Podman installation guide](/installation/container/podman). If the original container did not mount `/logs`, create the log volume first:
+The Podman workflow is the same replacement operation, using the image name from the [Podman installation guide](/installation/container/podman). If the original container did not mount `/logs`, include `podman volume create rustfs-logs` before recreating the container.
 
 ```bash
 podman volume create rustfs-logs
-```
-
-```bash
 podman inspect --format '{{.Config.Image}}' rustfs
 podman pull docker.io/rustfs/rustfs:<target-version>
 podman stop rustfs

--- a/content/en/reference/environment-variables.md
+++ b/content/en/reference/environment-variables.md
@@ -85,7 +85,7 @@ The observability pipeline exports traces, metrics, and logs over OTLP/HTTP.
 | `RUSTFS_OBS_ENVIRONMENT` | unset | Deployment environment label (`production`, `development`, `test`, `staging`). |
 | `RUSTFS_OBS_LOGGER_LEVEL` | unset | Log level filter (e.g. `info`, `debug`). |
 | `RUSTFS_OBS_LOG_STDOUT_ENABLED` | unset | Also mirror logs to stdout when file/OTLP logging is active. |
-| `RUSTFS_OBS_LOG_DIRECTORY` | unset | Local log directory. Unset means logs go to stdout; a URL value sends logs to a remote endpoint. |
+| `RUSTFS_OBS_LOG_DIRECTORY` | unset | Local log directory. Unset means logs go to stdout; a URL value sends logs to a remote endpoint. The official container image sets this to `/logs` (writable by UID `10001`). Do not use `/var/log/rustfs/` in container examples. |
 | `RUSTFS_OBS_LOG_FILENAME` | `rustfs.log` | Log filename inside the log directory. |
 | `RUSTFS_OBS_LOG_ROTATION_TIME` | `hourly` | Time-based log rotation: `daily`, `hourly`, `minutely`. |
 | `RUSTFS_OBS_LOG_KEEP_FILES` | `30` | Number of rotated log files to keep. |

--- a/content/fr/developer/integration/big-data/iceberg.md
+++ b/content/fr/developer/integration/big-data/iceberg.md
@@ -33,14 +33,12 @@ Create a working directory:
 mkdir rustfs-iceberg
 cd rustfs-iceberg
 ```
-
 Create an environment file and replace both credential placeholders:
 
 ```ini title=".env"
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Use dedicated credentials for the warehouse bucket. Do not commit `.env` to source control.
 
 Create the Spark catalog configuration:
@@ -57,7 +55,6 @@ spark.sql.catalog.demo.s3.path-style-access true
 spark.sql.defaultCatalog demo
 spark.sql.catalogImplementation in-memory
 ```
-
 Path-style access is required for this container-network endpoint. The hostname `rustfs` is resolvable only inside the Compose network; clients running on the host use `http://localhost:9000` instead.
 
 Create the Compose file:
@@ -74,7 +71,7 @@ services:
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     volumes:
       - rustfs-data:/data
     ports:
@@ -145,7 +142,6 @@ networks:
 volumes:
   rustfs-data:
 ```
-
 The [`rc` image](https://github.com/rustfs/cli) provides the official RustFS command-line client. The initializer checks for `my-bucket` before creating it, so repeated starts do not delete existing warehouse data. The RustFS volume preserves warehouse objects across container recreation.
 
 :::warning[Image versions]
@@ -161,20 +157,17 @@ Resolve the Compose file before starting containers:
 ```bash
 docker compose config
 ```
-
 Start the services and wait for the bucket initializer to finish:
 
 ```bash
 docker compose up -d
 docker compose ps -a
 ```
-
 The `create-bucket` service should show an exit code of `0`. Check its logs if it does not complete:
 
 ```bash
 docker compose logs create-bucket
 ```
-
 Open the RustFS Console at `http://localhost:9001`. The REST catalog is available at `http://localhost:8181`, and the Spark notebook server is available at `http://localhost:8888`.
 
 ## 3. Create and query an Iceberg table
@@ -184,7 +177,6 @@ Start Spark SQL:
 ```bash
 docker compose exec spark-iceberg spark-sql
 ```
-
 Create a namespace and a partitioned table:
 
 ```sql
@@ -200,7 +192,6 @@ CREATE TABLE demo.nyc.taxis
 )
 PARTITIONED BY (vendor_id);
 ```
-
 Insert and query sample rows:
 
 ```sql
@@ -213,7 +204,6 @@ VALUES
 
 SELECT * FROM demo.nyc.taxis ORDER BY trip_id;
 ```
-
 The query should return four rows:
 
 ```text
@@ -222,7 +212,6 @@ The query should return four rows:
 2  1000373  0.9  9.01   N
 1  1000374  8.4  42.13  Y
 ```
-
 ## 4. Verify objects in RustFS
 
 List the warehouse from the bucket-initializer image:
@@ -231,7 +220,6 @@ List the warehouse from the bucket-initializer image:
 docker compose run --rm --entrypoint /bin/sh create-bucket -c \
   '/usr/bin/rc alias set rustfs http://rustfs:9000 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY" >/dev/null && /usr/bin/rc find rustfs/my-bucket/warehouse'
 ```
-
 The output should include Iceberg metadata and data objects below the `warehouse/nyc/taxis` prefix. You can also inspect the `my-bucket` bucket in the RustFS Console.
 
 ## 5. Stop or reset the stack
@@ -241,13 +229,11 @@ Stop the containers while keeping the RustFS data volume:
 ```bash
 docker compose down
 ```
-
 To delete the local warehouse and start from an empty RustFS volume, explicitly include `--volumes`:
 
 ```bash
 docker compose down --volumes
 ```
-
 ## Troubleshooting
 
 ### Spark cannot reach RustFS
@@ -263,7 +249,6 @@ Check that the credentials in `.env` match the RustFS credentials and that the `
 ```bash
 docker compose logs create-bucket rest
 ```
-
 The REST catalog property uses doubled underscores in `CATALOG_IO__IMPL` and `CATALOG_S3_PATH__STYLE__ACCESS`; the fixture converts them to the dotted and hyphenated Iceberg property names.
 
 ## Next steps

--- a/content/fr/developer/integration/big-data/milvus.md
+++ b/content/fr/developer/integration/big-data/milvus.md
@@ -34,14 +34,12 @@ Create a working directory:
 mkdir rustfs-milvus
 cd rustfs-milvus
 ```
-
 Create an environment file and replace both credential placeholders:
 
 ```ini title=".env"
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Use dedicated credentials for the Milvus bucket. Do not commit `.env` to source control.
 
 Create the Milvus storage override:
@@ -61,7 +59,6 @@ minio:
   region: us-east-1
   useVirtualHost: false
 ```
-
 `useVirtualHost: false` selects path-style S3 requests. The hostname `rustfs` resolves inside the Compose network; clients on the host use `http://localhost:9000`.
 
 Create the Compose file:
@@ -100,7 +97,7 @@ services:
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     volumes:
       - rustfs-data:/data
     ports:
@@ -185,7 +182,6 @@ volumes:
   rustfs-data:
   milvus-data:
 ```
-
 The `create-bucket` service uses the official [`rc`](https://github.com/rustfs/cli) image and exits after ensuring that `my-bucket` exists. Named volumes preserve etcd metadata, RustFS objects, and Milvus local data when containers are recreated.
 
 :::warning[Protect local service ports]
@@ -201,20 +197,17 @@ Resolve the Compose file before starting containers:
 ```bash
 docker compose config
 ```
-
 Start the services:
 
 ```bash
 docker compose up -d
 docker compose ps -a
 ```
-
 The `create-bucket` service should exit with code `0`, and `etcd`, `rustfs`, and `standalone` should become healthy. Inspect logs if a service does not reach its expected state:
 
 ```bash
 docker compose logs create-bucket rustfs standalone
 ```
-
 Open these local interfaces:
 
 - RustFS Console: `http://localhost:9001`
@@ -232,7 +225,6 @@ python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install "pymilvus==2.6.0"
 ```
-
 Create a test script:
 
 ```python title="verify_milvus.py"
@@ -269,13 +261,11 @@ results = client.search(
 print(results)
 client.close()
 ```
-
 Run the script:
 
 ```bash
 python verify_milvus.py
 ```
-
 The result should rank the row with ID `1` first. Open Attu and confirm that the `rustfs_demo` collection contains three entities.
 
 ## 4. Verify Milvus objects in RustFS
@@ -286,7 +276,6 @@ Use the bucket-initializer image to list objects below the configured `milvus` r
 docker compose run --rm --entrypoint /bin/sh create-bucket -c \
   '/usr/bin/rc alias set rustfs http://rustfs:9000 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY" --region us-east-1 --bucket-lookup path >/dev/null && /usr/bin/rc find rustfs/my-bucket/milvus'
 ```
-
 The output should contain objects created by Milvus below the `milvus/` prefix. You can also open `my-bucket` in the RustFS Console.
 
 Milvus may buffer or compact data before every expected object appears. The successful insert, flush, query, and RustFS object listing together validate the integration path.
@@ -298,13 +287,11 @@ Stop the containers while retaining all named volumes:
 ```bash
 docker compose down
 ```
-
 To delete the local test data, including the Milvus bucket contents and etcd metadata, explicitly remove the volumes:
 
 ```bash
 docker compose down --volumes
 ```
-
 :::warning[Reset removes the test data]
 
 The `--volumes` option permanently deletes the named volumes used by this Compose project. Do not run it against data you need to retain.
@@ -322,7 +309,6 @@ Confirm that `useVirtualHost` remains `false` and that the credential values pas
 ```bash
 docker compose logs standalone rustfs
 ```
-
 ### The bucket initializer fails
 
 Check RustFS readiness and the initializer logs:
@@ -331,7 +317,6 @@ Check RustFS readiness and the initializer logs:
 curl -fsS http://localhost:9000/health/ready
 docker compose logs create-bucket
 ```
-
 Verify that `.env` contains non-empty credentials and that `docker compose config` resolves both variables.
 
 ### Milvus starts without existing data
@@ -346,7 +331,6 @@ The Attu container must use `standalone:19530`. A browser or host-side client us
 curl -fsS http://localhost:9091/healthz
 docker compose logs attu standalone
 ```
-
 ## Next steps
 
 - Review [S3 compatibility notes](/administration/protocols/s3) before enabling additional Milvus storage features.

--- a/content/fr/developer/integration/reverse-proxy/caddy.md
+++ b/content/fr/developer/integration/reverse-proxy/caddy.md
@@ -26,7 +26,6 @@ Create a directory for the deployment:
 mkdir rustfs-caddy
 cd rustfs-caddy
 ```
-
 ## 2. Set deployment variables
 
 Create an environment file and replace each value:
@@ -38,7 +37,6 @@ ACME_EMAIL=admin@example.com
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Use an email address that receives certificate notices. Do not commit `.env` to source control.
 
 ## 3. Configure Caddy
@@ -72,7 +70,6 @@ Create a Caddyfile with one site block for each RustFS endpoint:
 		}
 }
 ```
-
 Caddy preserves the incoming `Host` header, HTTP method, and request URI by default. It also forwards client information through `X-Forwarded-*` headers and handles Console WebSocket upgrades without additional header rules.
 
 ## 4. Create the Compose file
@@ -112,7 +109,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -135,7 +132,6 @@ volumes:
 networks:
   rustfs:
 ```
-
 The persistent `caddy-data` volume stores certificates, private keys, and ACME account state. Back up this volume and do not share its contents. Only Caddy publishes host ports; RustFS remains reachable inside the Compose network.
 
 ## 5. Validate and start the deployment
@@ -146,13 +142,11 @@ Render the Compose configuration and start RustFS:
 docker compose config
 docker compose up -d rustfs
 ```
-
 Validate the Caddyfile with the same image used by the deployment:
 
 ```bash
 docker compose run --rm --no-deps caddy caddy validate --config /etc/caddy/Caddyfile
 ```
-
 Start Caddy and check both services:
 
 ```bash
@@ -160,7 +154,6 @@ docker compose up -d caddy
 docker compose ps
 docker compose logs --follow caddy
 ```
-
 Caddy obtains certificates in the background and redirects HTTP requests to HTTPS. If issuance fails, confirm that both DNS records resolve to this host, ports `80` and `443` are reachable, and the `caddy-data` volume is writable.
 
 ## 6. Verify both endpoints
@@ -171,7 +164,6 @@ Verify the API and Console through their public HTTPS hostnames:
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 Configure S3 clients with `https://s3.example.com` as the endpoint and enable path-style addressing. Open `https://console.example.com` to sign in to the Console.
 
 ## Multi-node upstreams
@@ -199,7 +191,6 @@ For a distributed RustFS deployment, list every node in the corresponding site b
 		}
 }
 ```
-
 Replace `<your-cookie-secret>` with a random secret shared by all Caddy instances. Console affinity keeps an in-progress OpenID Connect login on the RustFS node that created its `state`. Keep port `9000` open directly between RustFS nodes because internal node RPC uses the same listener.
 
 ## Next steps

--- a/content/fr/developer/integration/reverse-proxy/haproxy.md
+++ b/content/fr/developer/integration/reverse-proxy/haproxy.md
@@ -26,14 +26,12 @@ Create directories for the HAProxy configuration and TLS certificate:
 mkdir -p rustfs-haproxy/config rustfs-haproxy/certs
 cd rustfs-haproxy
 ```
-
 HAProxy expects the certificate chain and private key in one PEM file. Combine them in this order:
 
 ```bash
 cat fullchain.pem privkey.pem > certs/rustfs.pem
 chmod 600 certs/rustfs.pem
 ```
-
 The certificate must cover both public hostnames.
 
 ## 2. Set RustFS credentials
@@ -44,7 +42,6 @@ Create an environment file and replace both credential placeholders:
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Do not commit this file or the certificate private key to source control.
 
 ## 3. Configure HAProxy
@@ -95,7 +92,6 @@ backend rustfs_console
     http-check expect status 200
     server rustfs rustfs:9001 check inter 10s fall 3 rise 2 cookie rustfs
 ```
-
 HAProxy preserves the incoming host and request path unless you explicitly rewrite them. The long client, server, and tunnel timeouts accommodate streaming S3 operations and Console WebSocket connections.
 
 The Console backend sets an affinity cookie. With one RustFS server it has no routing effect, but keeping it in the base configuration makes the behavior consistent when you add nodes.
@@ -131,7 +127,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -152,7 +148,6 @@ volumes:
 networks:
   rustfs:
 ```
-
 Only HAProxy publishes host ports. RustFS ports `9000` and `9001` remain reachable inside the Compose network.
 
 ## 5. Validate and start the deployment
@@ -163,27 +158,23 @@ Render the Compose configuration and start RustFS:
 docker compose config
 docker compose up -d rustfs
 ```
-
 Validate the HAProxy configuration with the same image used by the deployment:
 
 ```bash
 docker compose run --rm --no-deps haproxy haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg
 ```
-
 Start HAProxy and check both services:
 
 ```bash
 docker compose up -d haproxy
 docker compose ps
 ```
-
 If a service does not become healthy, inspect its logs:
 
 ```bash
 docker compose logs haproxy
 docker compose logs rustfs
 ```
-
 ## 6. Verify both endpoints
 
 Verify the API and Console through their public HTTPS hostnames:
@@ -192,7 +183,6 @@ Verify the API and Console through their public HTTPS hostnames:
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 Configure S3 clients with `https://s3.example.com` as the endpoint and enable path-style addressing. Open `https://console.example.com` to sign in to the Console.
 
 When you replace a renewed `certs/rustfs.pem`, validate the configuration and recreate the HAProxy container to load it:
@@ -201,7 +191,6 @@ When you replace a renewed `certs/rustfs.pem`, validate the configuration and re
 docker compose run --rm --no-deps haproxy haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg
 docker compose up -d --force-recreate haproxy
 ```
-
 ## Multi-node backends
 
 For a distributed RustFS deployment, add every RustFS node to both backends:
@@ -226,7 +215,6 @@ backend rustfs_console
 		server node3 node3.example.net:9001 check inter 10s fall 3 rise 2 cookie node3
 		server node4 node4.example.net:9001 check inter 10s fall 3 rise 2 cookie node4
 ```
-
 The Console cookie keeps an in-progress OpenID Connect login on the RustFS node that created its `state`. Keep port `9000` open directly between RustFS nodes because internal node RPC uses the same listener.
 
 ## Next steps

--- a/content/fr/developer/integration/reverse-proxy/nginx.md
+++ b/content/fr/developer/integration/reverse-proxy/nginx.md
@@ -26,7 +26,6 @@ Create directories for the Nginx configuration and TLS certificate:
 mkdir -p rustfs-nginx/sites rustfs-nginx/certs
 cd rustfs-nginx
 ```
-
 Copy your certificate chain and private key into `certs/`:
 
 ```text
@@ -36,13 +35,11 @@ rustfs-nginx/
 │   └── privkey.pem
 └── sites/
 ```
-
 Restrict access to the private key:
 
 ```bash
 chmod 600 certs/privkey.pem
 ```
-
 ## 2. Set RustFS credentials
 
 Create an environment file and replace both credential placeholders:
@@ -51,7 +48,6 @@ Create an environment file and replace both credential placeholders:
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Do not commit this file to source control.
 
 ## 3. Configure Nginx
@@ -136,7 +132,6 @@ server {
     }
 }
 ```
-
 The S3 server preserves the original host and request path, disables request buffering for streaming uploads, and does not convert signed `HEAD` requests. The Console server also forwards WebSocket upgrade headers.
 
 ## 4. Create the Compose file
@@ -170,7 +165,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -191,7 +186,6 @@ volumes:
 networks:
   rustfs:
 ```
-
 Only Nginx publishes host ports. RustFS ports `9000` and `9001` remain reachable inside the Compose network.
 
 ## 5. Validate and start the deployment
@@ -203,21 +197,18 @@ docker compose config
 docker compose up -d rustfs
 docker compose run --rm --no-deps nginx nginx -t
 ```
-
 Start Nginx and check both services:
 
 ```bash
 docker compose up -d nginx
 docker compose ps
 ```
-
 If a service does not become healthy, inspect its logs:
 
 ```bash
 docker compose logs nginx
 docker compose logs rustfs
 ```
-
 ## 6. Verify both endpoints
 
 Verify the API and Console through their public HTTPS hostnames:
@@ -226,7 +217,6 @@ Verify the API and Console through their public HTTPS hostnames:
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 Configure S3 clients with `https://s3.example.com` as the endpoint and enable path-style addressing. Open `https://console.example.com` to sign in to the Console.
 
 When you replace a renewed certificate or key in `certs/`, validate and reload Nginx without interrupting active connections:
@@ -235,7 +225,6 @@ When you replace a renewed certificate or key in `certs/`, validate and reload N
 docker compose exec nginx nginx -t
 docker compose exec nginx nginx -s reload
 ```
-
 ## Multi-node upstreams
 
 For a distributed RustFS deployment, replace the single server in each upstream with all RustFS nodes:
@@ -259,7 +248,6 @@ upstream rustfs_console {
   keepalive 16;
 }
 ```
-
 The Console upstream uses client affinity because an in-progress OpenID Connect login stores its `state` on one RustFS node. Keep port `9000` open between RustFS nodes because internal node RPC uses the same listener.
 
 ## Next steps

--- a/content/fr/developer/integration/reverse-proxy/traefik.md
+++ b/content/fr/developer/integration/reverse-proxy/traefik.md
@@ -28,7 +28,6 @@ cd rustfs-traefik
 touch acme.json
 chmod 600 acme.json
 ```
-
 ## 2. Set deployment variables
 
 Create an environment file and replace each value:
@@ -40,7 +39,6 @@ ACME_EMAIL=admin@example.com
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Use an email address that receives certificate expiration notices. Do not commit `.env` or `acme.json` to source control.
 
 ## 3. Create the Compose file
@@ -86,7 +84,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -125,7 +123,6 @@ networks:
   rustfs:
     name: rustfs
 ```
-
 The two routers use different host rules and backend ports. RustFS does not publish ports `9000` or `9001` on the Docker host, and the Traefik Dashboard is not exposed.
 
 :::note[Docker socket access]
@@ -141,20 +138,17 @@ Render the Compose configuration and check that all variables resolve:
 ```bash
 docker compose config
 ```
-
 Start both services:
 
 ```bash
 docker compose up -d
 docker compose ps
 ```
-
 Follow the Traefik logs while it completes the ACME challenge and creates both certificates:
 
 ```bash
 docker compose logs --follow traefik
 ```
-
 If certificate issuance fails, confirm that both DNS records resolve to this host and that ports `80` and `443` are reachable from the internet. Let's Encrypt rate limits apply, so correct DNS and firewall problems before repeatedly recreating the deployment.
 
 ## 5. Verify both endpoints
@@ -165,7 +159,6 @@ Verify the S3 API readiness endpoint and Console health endpoint through Traefik
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 Configure S3 clients with `https://s3.example.com` as the endpoint and enable path-style addressing. Open `https://console.example.com` to sign in to the Console.
 
 ## Multi-node services
@@ -181,7 +174,6 @@ services:
     volumes:
       - ./dynamic.yaml:/etc/traefik/dynamic.yaml:ro
 ```
-
 Create the dynamic configuration with every RustFS node:
 
 ```yaml title="dynamic.yaml"
@@ -233,7 +225,6 @@ http:
           - url: http://node3.example.net:9001
           - url: http://node4.example.net:9001
 ```
-
 Configure sticky sessions for the Console service when you use OpenID Connect. An in-progress login stores its `state` on one RustFS node and the callback must return to that node. Keep port `9000` open directly between RustFS nodes because internal node RPC uses the same listener.
 
 ## Next steps

--- a/content/fr/installation/container/docker.md
+++ b/content/fr/installation/container/docker.md
@@ -17,6 +17,11 @@ Create a named volume so object data remains available when you replace the cont
 
 ```bash
 docker volume create rustfs-data
+docker volume create rustfs-logs
+
+# Bind-mount alternative (host directories must be owned by 10001:10001):
+# mkdir -p data logs
+# sudo chown -R 10001:10001 data logs
 ```
 
 ## 3. Start RustFS
@@ -30,13 +35,14 @@ docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v rustfs-data:/data \
+  -v rustfs-logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   rustfs/rustfs:latest \
   /data
 ```
@@ -55,7 +61,6 @@ Check the container and the S3 API health endpoint:
 docker ps --filter name=rustfs
 curl --fail http://localhost:9000/health
 ```
-
 The S3 API is available at `http://localhost:9000`, and the Console is available at `http://localhost:9001`.
 
 ## Next steps

--- a/content/fr/installation/container/index.mdx
+++ b/content/fr/installation/container/index.mdx
@@ -32,7 +32,6 @@ Pull the official image (Alpine-based) from Docker Hub:
 ```bash
 docker pull rustfs/rustfs
 ```
-
 ---
 
 
@@ -47,10 +46,10 @@ RustFS SNSD Docker running method, combining the above image and configuration, 
   -p 9000:9000 \
   -p 9001:9001 \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   rustfs/rustfs:latest \
   /data
 ```
-
 Parameter descriptions:
 
 * `-p 9000:9000`: Map host port 9000 to container
@@ -67,27 +66,6 @@ Configuration can be passed as environment variables (recommended) or as command
 <Tabs items={["Environment variables", "Command-line flags"]}>
   <Tab value="Environment variables" id="docker-env-config">
 
-```bash {7,8}
-# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
-docker run -d \
-  --name rustfs \
-  -p 9000:9000 \
-  -p 9001:9001 \
-  -v /mnt/rustfs/data:/data \
-  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
-  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
-  -e RUSTFS_ADDRESS=":9000" \
-  -e RUSTFS_CONSOLE_ADDRESS=":9001" \
-  -e RUSTFS_CONSOLE_ENABLE=true \
-  -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
-  rustfs/rustfs:latest \
-  /data
-```
-
-  </Tab>
-  <Tab value="Command-line flags" id="docker-cli-config">
-
 ```bash {8,9}
 # Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
 docker run -d \
@@ -95,6 +73,28 @@ docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
+  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
+  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
+  -e RUSTFS_ADDRESS=":9000" \
+  -e RUSTFS_CONSOLE_ADDRESS=":9001" \
+  -e RUSTFS_CONSOLE_ENABLE=true \
+  -e RUSTFS_OBS_LOGGER_LEVEL=error \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
+  rustfs/rustfs:latest \
+  /data
+```
+  </Tab>
+  <Tab value="Command-line flags" id="docker-cli-config">
+
+```bash {9,10}
+# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
+docker run -d \
+  --name rustfs \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   rustfs/rustfs:latest \
   --access-key "<your-access-key>" \
   --secret-key "<your-secret-key>" \
@@ -102,7 +102,6 @@ docker run -d \
   --console-enable \
   /data
 ```
-
   </Tab>
 </Tabs>
 
@@ -114,6 +113,7 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
      rustfs/rustfs:latest \
      /data
    ```
@@ -124,11 +124,12 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
     -e RUSTFS_ADDRESS=":9000" \
     -e RUSTFS_CONSOLE_ADDRESS=":9001" \
     -e RUSTFS_CONSOLE_ENABLE=true \
     -e RUSTFS_OBS_LOGGER_LEVEL=error \
-    -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+    -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
      rustfs/rustfs:latest \
      --console-enable \
      /data
@@ -141,6 +142,7 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
      -e RUSTFS_ACCESS_KEY="<your-access-key>" \
      -e RUSTFS_SECRET_KEY="<your-secret-key>" \
      rustfs/rustfs:latest \
@@ -173,13 +175,11 @@ RustFS officially provides a Docker Compose installation method. The [`docker-co
 ```bash
 git clone https://github.com/rustfs/rustfs.git
 ```
-
 Running the command under root directory,
 
 ```bash
 docker compose --profile observability up -d
 ```
-
 Providing the necessary permissions. An initialization container is necessary to grant the correct access rights to rustfs using the `depends_on` keyword. In the example below the `rustfs_perms` service is added to the `docker-compose.yml` to handle this. To ensure logs are persisted and accessible, we map the host log directory to the container's `/var/log/rustfs/` path
 
 ```yaml title="docker-compose.yml"
@@ -199,17 +199,16 @@ Providing the necessary permissions. An initialization container is necessary to
           condition: service_completed_successfully
       volumes:
         - /path/to_host_directory/volumes/data:/data
-        - /path/to_host_directory/volumes/logs:/var/log/rustfs/
+        - /path/to_host_directory/volumes/logs:/logs
       environment:
         - RUSTFS_ADDRESS=":9000"
         - RUSTFS_CONSOLE_ADDRESS=":9001"
         - RUSTFS_CONSOLE_ENABLE=true
         - RUSTFS_OBS_LOGGER_LEVEL=error
-        - RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/"
+        - RUSTFS_OBS_LOG_DIRECTORY="/logs"
     
       # ... other configurations
 ```
-
 Started containers is as below,
 
 ```text
@@ -220,13 +219,11 @@ e3f4fc4a83a2   grafana/grafana:latest                            "/run.sh"      
 e7db806b2d6f   jaegertracing/all-in-one:latest                   "/go/bin/all-in-one-…"   7 seconds ago   Up 5 seconds                      4317-4318/tcp, 9411/tcp, 0.0.0.0:14250->14250/tcp, :::14250->14250/tcp, 14268/tcp, 0.0.0.0:16686->16686/tcp, :::16686->16686/tcp          jaeger
 1897830a2f1e   otel/opentelemetry-collector-contrib:latest       "/otelcol-contrib --…"   7 seconds ago   Up 5 seconds                      0.0.0.0:4317-4318->4317-4318/tcp, :::4317-4318->4317-4318/tcp, 0.0.0.0:8888-8889->8888-8889/tcp, :::8888-8889->8888-8889/tcp, 55679/tcp   otel-collector
 ```
-
 If you only want to install RustFS without Grafana, Prometheus, and the other observability services, start just the `rustfs` service (the compose file marks the collector dependency as optional):
 
 ```bash
 docker compose -f docker-compose.yml up -d rustfs
 ```
-
 This way will only install and start `rustfs-server` service, namely rustfs container,
 
 ```text
@@ -234,7 +231,6 @@ docker ps
 CONTAINER ID   IMAGE                                             COMMAND                  CREATED         STATUS                           PORTS                                                           NAMES
 e07121ecdd39   rustfs/rustfs:latest                              "/entrypoint.sh rust…"   2 seconds ago   Up 1 second (health: starting)   0.0.0.0:9000-9001->9000-9001/tcp, :::9000-9001->9000-9001/tcp   rustfs-server
 ```
-
 Whether you start only the `rustfs-server` or together with observability services, the S3 API is served at `http://localhost:9000`, and the RustFS Console is at `http://localhost:9001` — open it in a browser and log in with the access key and secret key you configured above (the `<your-access-key>` / `<your-secret-key>` placeholders). Generate a strong secret with, for example, `openssl rand -base64 24`, and never ship the placeholder values to production.
 
 :::warning[Set container credentials immediately]
@@ -278,17 +274,17 @@ docker run -d \
   --name rustfs \
   --network host \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   -e RUSTFS_VOLUMES="http://node{1...4}:9000/data/rustfs{0...3}" \
   rustfs/rustfs:latest
 ```
-
 Add the entries to `/etc/hosts` on **every** node:
 ```ini title="/etc/hosts"
 192.168.1.1 node1
@@ -296,7 +292,6 @@ Add the entries to `/etc/hosts` on **every** node:
 192.168.1.3 node3
 192.168.1.4 node4
 ```
-
 ## 6. Other Recommendations
 
 1. Production Environment Recommendations:

--- a/content/fr/installation/container/podman.md
+++ b/content/fr/installation/container/podman.md
@@ -17,6 +17,11 @@ Create a named volume so object data remains available when you replace the cont
 
 ```bash
 podman volume create rustfs-data
+podman volume create rustfs-logs
+
+# Bind-mount alternative on SELinux hosts (`:U` sets ownership; `:Z` sets the SELinux label):
+# mkdir -p data logs
+# podman run ... -v "$(pwd)/data":/data:Z,U -v "$(pwd)/logs":/logs:Z,U ...
 ```
 
 ## 3. Start RustFS
@@ -29,13 +34,14 @@ podman run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v rustfs-data:/data \
+  -v rustfs-logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   docker.io/rustfs/rustfs:latest \
   /data
 ```
@@ -54,7 +60,6 @@ Check the container and the S3 API health endpoint:
 podman ps --filter name=rustfs
 curl --fail http://localhost:9000/health
 ```
-
 The S3 API is available at `http://localhost:9000`, and the Console is available at `http://localhost:9001`.
 
 ## Next steps

--- a/content/fr/operations/observability.md
+++ b/content/fr/operations/observability.md
@@ -12,14 +12,12 @@ RustFS (RUSTFS_OBS_ENDPOINT) --OTLP--> OpenTelemetry Collector --> Prometheus --
                                                               \--> Loki (logs)
                                                               \--> Tempo / Jaeger (traces)
 ```
-
 Point RustFS at the Collector with:
 
 ```bash
 # OTLP over HTTP (the Collector's default HTTP receiver port is 4318; gRPC is 4317)
 RUSTFS_OBS_ENDPOINT=http://otel-collector:4318
 ```
-
 Related environment variables (all defined in the server configuration):
 
 | Variable | Purpose |
@@ -53,7 +51,6 @@ service:
       receivers: [otlp]
       exporters: [prometheus]
 ```
-
 Prometheus then scrapes the Collector, not RustFS:
 
 ```yaml
@@ -66,7 +63,6 @@ scrape_configs:
     static_configs:
       - targets: ["otel-collector:8888"]   # Collector self-metrics
 ```
-
 :::note
 
 If Prometheus shows no `rustfs_*` series, check the chain in order: is `RUSTFS_OBS_ENDPOINT` set on every node, is the Collector reachable from the nodes, and is Prometheus scraping the Collector's `8889` exporter port.
@@ -219,6 +215,7 @@ RUSTFS_ADDRESS=":9000"
 RUSTFS_CONSOLE_ADDRESS=":9001"
 RUSTFS_CONSOLE_ENABLE=true
 RUSTFS_OBS_LOGGER_LEVEL=error
+# Linux packages use /var/log/rustfs/; the container image uses /logs.
 RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/"
 RUSTFS_OBS_ENDPOINT=http://otel-collector:4318
 ```

--- a/content/fr/operations/upgrade/container/index.md
+++ b/content/fr/operations/upgrade/container/index.md
@@ -28,17 +28,16 @@ The following workflow matches the container name and named volume used in the [
 Record the current image, then pull the target version:
 
 ```bash
+docker volume create rustfs-logs
 docker inspect --format '{{.Config.Image}}' rustfs
 docker pull rustfs/rustfs:<target-version>
 ```
-
 Stop and remove only the container. The `rustfs-data` volume remains intact:
 
 ```bash
 docker stop rustfs
 docker rm rustfs
 ```
-
 Recreate the container with the original configuration and the target image:
 
 ```bash
@@ -48,17 +47,17 @@ docker run -d \
 	-p 9000:9000 \
 	-p 9001:9001 \
 	-v rustfs-data:/data \
+	-v rustfs-logs:/logs \
 	-e RUSTFS_ACCESS_KEY="<your-access-key>" \
 	-e RUSTFS_SECRET_KEY="<your-secret-key>" \
 	-e RUSTFS_ADDRESS=":9000" \
 	-e RUSTFS_CONSOLE_ADDRESS=":9001" \
 	-e RUSTFS_CONSOLE_ENABLE=true \
 	-e RUSTFS_OBS_LOGGER_LEVEL=error \
-	-e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+	-e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
 	rustfs/rustfs:<target-version> \
 	/data
 ```
-
 Wait for the replacement container to become healthy:
 
 ```bash
@@ -72,12 +71,12 @@ curl -fsS http://localhost:9000/health/ready
 The Podman workflow is the same replacement operation, using the image name from the [Podman installation guide](/installation/container/podman).
 
 ```bash
+podman volume create rustfs-logs
 podman inspect --format '{{.Config.Image}}' rustfs
 podman pull docker.io/rustfs/rustfs:<target-version>
 podman stop rustfs
 podman rm rustfs
 ```
-
 Recreate the container with the original configuration and persistent volume:
 
 ```bash
@@ -86,17 +85,17 @@ podman run -d \
 	-p 9000:9000 \
 	-p 9001:9001 \
 	-v rustfs-data:/data \
+	-v rustfs-logs:/logs \
 	-e RUSTFS_ACCESS_KEY="<your-access-key>" \
 	-e RUSTFS_SECRET_KEY="<your-secret-key>" \
 	-e RUSTFS_ADDRESS=":9000" \
 	-e RUSTFS_CONSOLE_ADDRESS=":9001" \
 	-e RUSTFS_CONSOLE_ENABLE=true \
 	-e RUSTFS_OBS_LOGGER_LEVEL=error \
-	-e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+	-e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
 	docker.io/rustfs/rustfs:<target-version> \
 	/data
 ```
-
 Verify the replacement before continuing:
 
 ```bash
@@ -113,7 +112,6 @@ Run Compose commands from the directory containing the deployment's `docker-comp
 docker compose config > docker-compose.resolved.yaml
 docker compose images rustfs
 ```
-
 Change the `rustfs` service to an explicit target image tag while leaving its volumes, environment, ports, and command unchanged:
 
 ```yaml title="docker-compose.yml"
@@ -121,7 +119,6 @@ services:
 	rustfs:
 		image: rustfs/rustfs:<target-version>
 ```
-
 Validate the file, pull the target image, and recreate only the RustFS service. `--no-deps` leaves optional observability services running:
 
 ```bash
@@ -129,7 +126,6 @@ docker compose config --quiet
 docker compose pull rustfs
 docker compose up -d --no-deps rustfs
 ```
-
 Check the service and the RustFS readiness endpoint:
 
 ```bash
@@ -137,7 +133,6 @@ docker compose ps rustfs
 docker compose logs --tail=100 rustfs
 curl -fsS http://localhost:9000/health/ready
 ```
-
 If you started RustFS together with the `observability` profile, the RustFS service still upgrades with the same commands. Upgrade observability images separately according to each component's release notes.
 
 ## Upgrade a multi-node deployment
@@ -157,7 +152,6 @@ docker compose pull rustfs
 docker compose up -d --no-deps rustfs
 curl -fsS http://localhost:9000/health/ready
 ```
-
 In a multi-node deployment, roll back one node at a time and wait for readiness before continuing.
 
 ## Next steps

--- a/content/ja/developer/integration/big-data/iceberg.md
+++ b/content/ja/developer/integration/big-data/iceberg.md
@@ -33,14 +33,12 @@ Create a working directory:
 mkdir rustfs-iceberg
 cd rustfs-iceberg
 ```
-
 Create an environment file and replace both credential placeholders:
 
 ```ini title=".env"
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Use dedicated credentials for the warehouse bucket. Do not commit `.env` to source control.
 
 Create the Spark catalog configuration:
@@ -57,7 +55,6 @@ spark.sql.catalog.demo.s3.path-style-access true
 spark.sql.defaultCatalog demo
 spark.sql.catalogImplementation in-memory
 ```
-
 Path-style access is required for this container-network endpoint. The hostname `rustfs` is resolvable only inside the Compose network; clients running on the host use `http://localhost:9000` instead.
 
 Create the Compose file:
@@ -74,7 +71,7 @@ services:
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     volumes:
       - rustfs-data:/data
     ports:
@@ -145,7 +142,6 @@ networks:
 volumes:
   rustfs-data:
 ```
-
 The [`rc` image](https://github.com/rustfs/cli) provides the official RustFS command-line client. The initializer checks for `my-bucket` before creating it, so repeated starts do not delete existing warehouse data. The RustFS volume preserves warehouse objects across container recreation.
 
 :::warning[Image versions]
@@ -161,20 +157,17 @@ Resolve the Compose file before starting containers:
 ```bash
 docker compose config
 ```
-
 Start the services and wait for the bucket initializer to finish:
 
 ```bash
 docker compose up -d
 docker compose ps -a
 ```
-
 The `create-bucket` service should show an exit code of `0`. Check its logs if it does not complete:
 
 ```bash
 docker compose logs create-bucket
 ```
-
 Open the RustFS Console at `http://localhost:9001`. The REST catalog is available at `http://localhost:8181`, and the Spark notebook server is available at `http://localhost:8888`.
 
 ## 3. Create and query an Iceberg table
@@ -184,7 +177,6 @@ Start Spark SQL:
 ```bash
 docker compose exec spark-iceberg spark-sql
 ```
-
 Create a namespace and a partitioned table:
 
 ```sql
@@ -200,7 +192,6 @@ CREATE TABLE demo.nyc.taxis
 )
 PARTITIONED BY (vendor_id);
 ```
-
 Insert and query sample rows:
 
 ```sql
@@ -213,7 +204,6 @@ VALUES
 
 SELECT * FROM demo.nyc.taxis ORDER BY trip_id;
 ```
-
 The query should return four rows:
 
 ```text
@@ -222,7 +212,6 @@ The query should return four rows:
 2  1000373  0.9  9.01   N
 1  1000374  8.4  42.13  Y
 ```
-
 ## 4. Verify objects in RustFS
 
 List the warehouse from the bucket-initializer image:
@@ -231,7 +220,6 @@ List the warehouse from the bucket-initializer image:
 docker compose run --rm --entrypoint /bin/sh create-bucket -c \
   '/usr/bin/rc alias set rustfs http://rustfs:9000 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY" >/dev/null && /usr/bin/rc find rustfs/my-bucket/warehouse'
 ```
-
 The output should include Iceberg metadata and data objects below the `warehouse/nyc/taxis` prefix. You can also inspect the `my-bucket` bucket in the RustFS Console.
 
 ## 5. Stop or reset the stack
@@ -241,13 +229,11 @@ Stop the containers while keeping the RustFS data volume:
 ```bash
 docker compose down
 ```
-
 To delete the local warehouse and start from an empty RustFS volume, explicitly include `--volumes`:
 
 ```bash
 docker compose down --volumes
 ```
-
 ## Troubleshooting
 
 ### Spark cannot reach RustFS
@@ -263,7 +249,6 @@ Check that the credentials in `.env` match the RustFS credentials and that the `
 ```bash
 docker compose logs create-bucket rest
 ```
-
 The REST catalog property uses doubled underscores in `CATALOG_IO__IMPL` and `CATALOG_S3_PATH__STYLE__ACCESS`; the fixture converts them to the dotted and hyphenated Iceberg property names.
 
 ## Next steps

--- a/content/ja/developer/integration/big-data/milvus.md
+++ b/content/ja/developer/integration/big-data/milvus.md
@@ -34,14 +34,12 @@ Create a working directory:
 mkdir rustfs-milvus
 cd rustfs-milvus
 ```
-
 Create an environment file and replace both credential placeholders:
 
 ```ini title=".env"
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Use dedicated credentials for the Milvus bucket. Do not commit `.env` to source control.
 
 Create the Milvus storage override:
@@ -61,7 +59,6 @@ minio:
   region: us-east-1
   useVirtualHost: false
 ```
-
 `useVirtualHost: false` selects path-style S3 requests. The hostname `rustfs` resolves inside the Compose network; clients on the host use `http://localhost:9000`.
 
 Create the Compose file:
@@ -100,7 +97,7 @@ services:
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     volumes:
       - rustfs-data:/data
     ports:
@@ -185,7 +182,6 @@ volumes:
   rustfs-data:
   milvus-data:
 ```
-
 The `create-bucket` service uses the official [`rc`](https://github.com/rustfs/cli) image and exits after ensuring that `my-bucket` exists. Named volumes preserve etcd metadata, RustFS objects, and Milvus local data when containers are recreated.
 
 :::warning[Protect local service ports]
@@ -201,20 +197,17 @@ Resolve the Compose file before starting containers:
 ```bash
 docker compose config
 ```
-
 Start the services:
 
 ```bash
 docker compose up -d
 docker compose ps -a
 ```
-
 The `create-bucket` service should exit with code `0`, and `etcd`, `rustfs`, and `standalone` should become healthy. Inspect logs if a service does not reach its expected state:
 
 ```bash
 docker compose logs create-bucket rustfs standalone
 ```
-
 Open these local interfaces:
 
 - RustFS Console: `http://localhost:9001`
@@ -232,7 +225,6 @@ python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install "pymilvus==2.6.0"
 ```
-
 Create a test script:
 
 ```python title="verify_milvus.py"
@@ -269,13 +261,11 @@ results = client.search(
 print(results)
 client.close()
 ```
-
 Run the script:
 
 ```bash
 python verify_milvus.py
 ```
-
 The result should rank the row with ID `1` first. Open Attu and confirm that the `rustfs_demo` collection contains three entities.
 
 ## 4. Verify Milvus objects in RustFS
@@ -286,7 +276,6 @@ Use the bucket-initializer image to list objects below the configured `milvus` r
 docker compose run --rm --entrypoint /bin/sh create-bucket -c \
   '/usr/bin/rc alias set rustfs http://rustfs:9000 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY" --region us-east-1 --bucket-lookup path >/dev/null && /usr/bin/rc find rustfs/my-bucket/milvus'
 ```
-
 The output should contain objects created by Milvus below the `milvus/` prefix. You can also open `my-bucket` in the RustFS Console.
 
 Milvus may buffer or compact data before every expected object appears. The successful insert, flush, query, and RustFS object listing together validate the integration path.
@@ -298,13 +287,11 @@ Stop the containers while retaining all named volumes:
 ```bash
 docker compose down
 ```
-
 To delete the local test data, including the Milvus bucket contents and etcd metadata, explicitly remove the volumes:
 
 ```bash
 docker compose down --volumes
 ```
-
 :::warning[Reset removes the test data]
 
 The `--volumes` option permanently deletes the named volumes used by this Compose project. Do not run it against data you need to retain.
@@ -322,7 +309,6 @@ Confirm that `useVirtualHost` remains `false` and that the credential values pas
 ```bash
 docker compose logs standalone rustfs
 ```
-
 ### The bucket initializer fails
 
 Check RustFS readiness and the initializer logs:
@@ -331,7 +317,6 @@ Check RustFS readiness and the initializer logs:
 curl -fsS http://localhost:9000/health/ready
 docker compose logs create-bucket
 ```
-
 Verify that `.env` contains non-empty credentials and that `docker compose config` resolves both variables.
 
 ### Milvus starts without existing data
@@ -346,7 +331,6 @@ The Attu container must use `standalone:19530`. A browser or host-side client us
 curl -fsS http://localhost:9091/healthz
 docker compose logs attu standalone
 ```
-
 ## Next steps
 
 - Review [S3 compatibility notes](/administration/protocols/s3) before enabling additional Milvus storage features.

--- a/content/ja/developer/integration/reverse-proxy/caddy.md
+++ b/content/ja/developer/integration/reverse-proxy/caddy.md
@@ -26,7 +26,6 @@ Create a directory for the deployment:
 mkdir rustfs-caddy
 cd rustfs-caddy
 ```
-
 ## 2. Set deployment variables
 
 Create an environment file and replace each value:
@@ -38,7 +37,6 @@ ACME_EMAIL=admin@example.com
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Use an email address that receives certificate notices. Do not commit `.env` to source control.
 
 ## 3. Configure Caddy
@@ -72,7 +70,6 @@ Create a Caddyfile with one site block for each RustFS endpoint:
 		}
 }
 ```
-
 Caddy preserves the incoming `Host` header, HTTP method, and request URI by default. It also forwards client information through `X-Forwarded-*` headers and handles Console WebSocket upgrades without additional header rules.
 
 ## 4. Create the Compose file
@@ -112,7 +109,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -135,7 +132,6 @@ volumes:
 networks:
   rustfs:
 ```
-
 The persistent `caddy-data` volume stores certificates, private keys, and ACME account state. Back up this volume and do not share its contents. Only Caddy publishes host ports; RustFS remains reachable inside the Compose network.
 
 ## 5. Validate and start the deployment
@@ -146,13 +142,11 @@ Render the Compose configuration and start RustFS:
 docker compose config
 docker compose up -d rustfs
 ```
-
 Validate the Caddyfile with the same image used by the deployment:
 
 ```bash
 docker compose run --rm --no-deps caddy caddy validate --config /etc/caddy/Caddyfile
 ```
-
 Start Caddy and check both services:
 
 ```bash
@@ -160,7 +154,6 @@ docker compose up -d caddy
 docker compose ps
 docker compose logs --follow caddy
 ```
-
 Caddy obtains certificates in the background and redirects HTTP requests to HTTPS. If issuance fails, confirm that both DNS records resolve to this host, ports `80` and `443` are reachable, and the `caddy-data` volume is writable.
 
 ## 6. Verify both endpoints
@@ -171,7 +164,6 @@ Verify the API and Console through their public HTTPS hostnames:
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 Configure S3 clients with `https://s3.example.com` as the endpoint and enable path-style addressing. Open `https://console.example.com` to sign in to the Console.
 
 ## Multi-node upstreams
@@ -199,7 +191,6 @@ For a distributed RustFS deployment, list every node in the corresponding site b
 		}
 }
 ```
-
 Replace `<your-cookie-secret>` with a random secret shared by all Caddy instances. Console affinity keeps an in-progress OpenID Connect login on the RustFS node that created its `state`. Keep port `9000` open directly between RustFS nodes because internal node RPC uses the same listener.
 
 ## Next steps

--- a/content/ja/developer/integration/reverse-proxy/haproxy.md
+++ b/content/ja/developer/integration/reverse-proxy/haproxy.md
@@ -26,14 +26,12 @@ Create directories for the HAProxy configuration and TLS certificate:
 mkdir -p rustfs-haproxy/config rustfs-haproxy/certs
 cd rustfs-haproxy
 ```
-
 HAProxy expects the certificate chain and private key in one PEM file. Combine them in this order:
 
 ```bash
 cat fullchain.pem privkey.pem > certs/rustfs.pem
 chmod 600 certs/rustfs.pem
 ```
-
 The certificate must cover both public hostnames.
 
 ## 2. Set RustFS credentials
@@ -44,7 +42,6 @@ Create an environment file and replace both credential placeholders:
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Do not commit this file or the certificate private key to source control.
 
 ## 3. Configure HAProxy
@@ -95,7 +92,6 @@ backend rustfs_console
     http-check expect status 200
     server rustfs rustfs:9001 check inter 10s fall 3 rise 2 cookie rustfs
 ```
-
 HAProxy preserves the incoming host and request path unless you explicitly rewrite them. The long client, server, and tunnel timeouts accommodate streaming S3 operations and Console WebSocket connections.
 
 The Console backend sets an affinity cookie. With one RustFS server it has no routing effect, but keeping it in the base configuration makes the behavior consistent when you add nodes.
@@ -131,7 +127,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -152,7 +148,6 @@ volumes:
 networks:
   rustfs:
 ```
-
 Only HAProxy publishes host ports. RustFS ports `9000` and `9001` remain reachable inside the Compose network.
 
 ## 5. Validate and start the deployment
@@ -163,27 +158,23 @@ Render the Compose configuration and start RustFS:
 docker compose config
 docker compose up -d rustfs
 ```
-
 Validate the HAProxy configuration with the same image used by the deployment:
 
 ```bash
 docker compose run --rm --no-deps haproxy haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg
 ```
-
 Start HAProxy and check both services:
 
 ```bash
 docker compose up -d haproxy
 docker compose ps
 ```
-
 If a service does not become healthy, inspect its logs:
 
 ```bash
 docker compose logs haproxy
 docker compose logs rustfs
 ```
-
 ## 6. Verify both endpoints
 
 Verify the API and Console through their public HTTPS hostnames:
@@ -192,7 +183,6 @@ Verify the API and Console through their public HTTPS hostnames:
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 Configure S3 clients with `https://s3.example.com` as the endpoint and enable path-style addressing. Open `https://console.example.com` to sign in to the Console.
 
 When you replace a renewed `certs/rustfs.pem`, validate the configuration and recreate the HAProxy container to load it:
@@ -201,7 +191,6 @@ When you replace a renewed `certs/rustfs.pem`, validate the configuration and re
 docker compose run --rm --no-deps haproxy haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg
 docker compose up -d --force-recreate haproxy
 ```
-
 ## Multi-node backends
 
 For a distributed RustFS deployment, add every RustFS node to both backends:
@@ -226,7 +215,6 @@ backend rustfs_console
 		server node3 node3.example.net:9001 check inter 10s fall 3 rise 2 cookie node3
 		server node4 node4.example.net:9001 check inter 10s fall 3 rise 2 cookie node4
 ```
-
 The Console cookie keeps an in-progress OpenID Connect login on the RustFS node that created its `state`. Keep port `9000` open directly between RustFS nodes because internal node RPC uses the same listener.
 
 ## Next steps

--- a/content/ja/developer/integration/reverse-proxy/nginx.md
+++ b/content/ja/developer/integration/reverse-proxy/nginx.md
@@ -26,7 +26,6 @@ Create directories for the Nginx configuration and TLS certificate:
 mkdir -p rustfs-nginx/sites rustfs-nginx/certs
 cd rustfs-nginx
 ```
-
 Copy your certificate chain and private key into `certs/`:
 
 ```text
@@ -36,13 +35,11 @@ rustfs-nginx/
 │   └── privkey.pem
 └── sites/
 ```
-
 Restrict access to the private key:
 
 ```bash
 chmod 600 certs/privkey.pem
 ```
-
 ## 2. Set RustFS credentials
 
 Create an environment file and replace both credential placeholders:
@@ -51,7 +48,6 @@ Create an environment file and replace both credential placeholders:
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Do not commit this file to source control.
 
 ## 3. Configure Nginx
@@ -136,7 +132,6 @@ server {
     }
 }
 ```
-
 The S3 server preserves the original host and request path, disables request buffering for streaming uploads, and does not convert signed `HEAD` requests. The Console server also forwards WebSocket upgrade headers.
 
 ## 4. Create the Compose file
@@ -170,7 +165,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -191,7 +186,6 @@ volumes:
 networks:
   rustfs:
 ```
-
 Only Nginx publishes host ports. RustFS ports `9000` and `9001` remain reachable inside the Compose network.
 
 ## 5. Validate and start the deployment
@@ -203,21 +197,18 @@ docker compose config
 docker compose up -d rustfs
 docker compose run --rm --no-deps nginx nginx -t
 ```
-
 Start Nginx and check both services:
 
 ```bash
 docker compose up -d nginx
 docker compose ps
 ```
-
 If a service does not become healthy, inspect its logs:
 
 ```bash
 docker compose logs nginx
 docker compose logs rustfs
 ```
-
 ## 6. Verify both endpoints
 
 Verify the API and Console through their public HTTPS hostnames:
@@ -226,7 +217,6 @@ Verify the API and Console through their public HTTPS hostnames:
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 Configure S3 clients with `https://s3.example.com` as the endpoint and enable path-style addressing. Open `https://console.example.com` to sign in to the Console.
 
 When you replace a renewed certificate or key in `certs/`, validate and reload Nginx without interrupting active connections:
@@ -235,7 +225,6 @@ When you replace a renewed certificate or key in `certs/`, validate and reload N
 docker compose exec nginx nginx -t
 docker compose exec nginx nginx -s reload
 ```
-
 ## Multi-node upstreams
 
 For a distributed RustFS deployment, replace the single server in each upstream with all RustFS nodes:
@@ -259,7 +248,6 @@ upstream rustfs_console {
   keepalive 16;
 }
 ```
-
 The Console upstream uses client affinity because an in-progress OpenID Connect login stores its `state` on one RustFS node. Keep port `9000` open between RustFS nodes because internal node RPC uses the same listener.
 
 ## Next steps

--- a/content/ja/developer/integration/reverse-proxy/traefik.md
+++ b/content/ja/developer/integration/reverse-proxy/traefik.md
@@ -28,7 +28,6 @@ cd rustfs-traefik
 touch acme.json
 chmod 600 acme.json
 ```
-
 ## 2. Set deployment variables
 
 Create an environment file and replace each value:
@@ -40,7 +39,6 @@ ACME_EMAIL=admin@example.com
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 Use an email address that receives certificate expiration notices. Do not commit `.env` or `acme.json` to source control.
 
 ## 3. Create the Compose file
@@ -86,7 +84,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -125,7 +123,6 @@ networks:
   rustfs:
     name: rustfs
 ```
-
 The two routers use different host rules and backend ports. RustFS does not publish ports `9000` or `9001` on the Docker host, and the Traefik Dashboard is not exposed.
 
 :::note[Docker socket access]
@@ -141,20 +138,17 @@ Render the Compose configuration and check that all variables resolve:
 ```bash
 docker compose config
 ```
-
 Start both services:
 
 ```bash
 docker compose up -d
 docker compose ps
 ```
-
 Follow the Traefik logs while it completes the ACME challenge and creates both certificates:
 
 ```bash
 docker compose logs --follow traefik
 ```
-
 If certificate issuance fails, confirm that both DNS records resolve to this host and that ports `80` and `443` are reachable from the internet. Let's Encrypt rate limits apply, so correct DNS and firewall problems before repeatedly recreating the deployment.
 
 ## 5. Verify both endpoints
@@ -165,7 +159,6 @@ Verify the S3 API readiness endpoint and Console health endpoint through Traefik
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 Configure S3 clients with `https://s3.example.com` as the endpoint and enable path-style addressing. Open `https://console.example.com` to sign in to the Console.
 
 ## Multi-node services
@@ -181,7 +174,6 @@ services:
     volumes:
       - ./dynamic.yaml:/etc/traefik/dynamic.yaml:ro
 ```
-
 Create the dynamic configuration with every RustFS node:
 
 ```yaml title="dynamic.yaml"
@@ -233,7 +225,6 @@ http:
           - url: http://node3.example.net:9001
           - url: http://node4.example.net:9001
 ```
-
 Configure sticky sessions for the Console service when you use OpenID Connect. An in-progress login stores its `state` on one RustFS node and the callback must return to that node. Keep port `9000` open directly between RustFS nodes because internal node RPC uses the same listener.
 
 ## Next steps

--- a/content/ja/installation/container/docker.md
+++ b/content/ja/installation/container/docker.md
@@ -17,6 +17,11 @@ Create a named volume so object data remains available when you replace the cont
 
 ```bash
 docker volume create rustfs-data
+docker volume create rustfs-logs
+
+# Bind-mount alternative (host directories must be owned by 10001:10001):
+# mkdir -p data logs
+# sudo chown -R 10001:10001 data logs
 ```
 
 ## 3. Start RustFS
@@ -30,13 +35,14 @@ docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v rustfs-data:/data \
+  -v rustfs-logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   rustfs/rustfs:latest \
   /data
 ```
@@ -55,7 +61,6 @@ Check the container and the S3 API health endpoint:
 docker ps --filter name=rustfs
 curl --fail http://localhost:9000/health
 ```
-
 The S3 API is available at `http://localhost:9000`, and the Console is available at `http://localhost:9001`.
 
 ## Next steps

--- a/content/ja/installation/container/index.mdx
+++ b/content/ja/installation/container/index.mdx
@@ -32,7 +32,6 @@ Pull the official image (Alpine-based) from Docker Hub:
 ```bash
 docker pull rustfs/rustfs
 ```
-
 ---
 
 
@@ -47,10 +46,10 @@ RustFS SNSD Docker running method, combining the above image and configuration, 
   -p 9000:9000 \
   -p 9001:9001 \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   rustfs/rustfs:latest \
   /data
 ```
-
 Parameter descriptions:
 
 * `-p 9000:9000`: Map host port 9000 to container
@@ -67,27 +66,6 @@ Configuration can be passed as environment variables (recommended) or as command
 <Tabs items={["Environment variables", "Command-line flags"]}>
   <Tab value="Environment variables" id="docker-env-config">
 
-```bash {7,8}
-# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
-docker run -d \
-  --name rustfs \
-  -p 9000:9000 \
-  -p 9001:9001 \
-  -v /mnt/rustfs/data:/data \
-  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
-  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
-  -e RUSTFS_ADDRESS=":9000" \
-  -e RUSTFS_CONSOLE_ADDRESS=":9001" \
-  -e RUSTFS_CONSOLE_ENABLE=true \
-  -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
-  rustfs/rustfs:latest \
-  /data
-```
-
-  </Tab>
-  <Tab value="Command-line flags" id="docker-cli-config">
-
 ```bash {8,9}
 # Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
 docker run -d \
@@ -95,6 +73,28 @@ docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
+  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
+  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
+  -e RUSTFS_ADDRESS=":9000" \
+  -e RUSTFS_CONSOLE_ADDRESS=":9001" \
+  -e RUSTFS_CONSOLE_ENABLE=true \
+  -e RUSTFS_OBS_LOGGER_LEVEL=error \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
+  rustfs/rustfs:latest \
+  /data
+```
+  </Tab>
+  <Tab value="Command-line flags" id="docker-cli-config">
+
+```bash {9,10}
+# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
+docker run -d \
+  --name rustfs \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   rustfs/rustfs:latest \
   --access-key "<your-access-key>" \
   --secret-key "<your-secret-key>" \
@@ -102,7 +102,6 @@ docker run -d \
   --console-enable \
   /data
 ```
-
   </Tab>
 </Tabs>
 
@@ -114,6 +113,7 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
      rustfs/rustfs:latest \
      /data
    ```
@@ -124,11 +124,12 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
     -e RUSTFS_ADDRESS=":9000" \
     -e RUSTFS_CONSOLE_ADDRESS=":9001" \
     -e RUSTFS_CONSOLE_ENABLE=true \
     -e RUSTFS_OBS_LOGGER_LEVEL=error \
-    -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+    -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
      rustfs/rustfs:latest \
      --console-enable \
      /data
@@ -141,6 +142,7 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
      -e RUSTFS_ACCESS_KEY="<your-access-key>" \
      -e RUSTFS_SECRET_KEY="<your-secret-key>" \
      rustfs/rustfs:latest \
@@ -173,13 +175,11 @@ RustFS officially provides a Docker Compose installation method. The [`docker-co
 ```bash
 git clone https://github.com/rustfs/rustfs.git
 ```
-
 Running the command under root directory,
 
 ```bash
 docker compose --profile observability up -d
 ```
-
 Providing the necessary permissions. An initialization container is necessary to grant the correct access rights to rustfs using the `depends_on` keyword. In the example below the `rustfs_perms` service is added to the `docker-compose.yml` to handle this. To ensure logs are persisted and accessible, we map the host log directory to the container's `/var/log/rustfs/` path
 
 ```yaml title="docker-compose.yml"
@@ -199,17 +199,16 @@ Providing the necessary permissions. An initialization container is necessary to
           condition: service_completed_successfully
       volumes:
         - /path/to_host_directory/volumes/data:/data
-        - /path/to_host_directory/volumes/logs:/var/log/rustfs/
+        - /path/to_host_directory/volumes/logs:/logs
       environment:
         - RUSTFS_ADDRESS=":9000"
         - RUSTFS_CONSOLE_ADDRESS=":9001"
         - RUSTFS_CONSOLE_ENABLE=true
         - RUSTFS_OBS_LOGGER_LEVEL=error
-        - RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/"
+        - RUSTFS_OBS_LOG_DIRECTORY="/logs"
     
       # ... other configurations
 ```
-
 Started containers is as below,
 
 ```text
@@ -220,13 +219,11 @@ e3f4fc4a83a2   grafana/grafana:latest                            "/run.sh"      
 e7db806b2d6f   jaegertracing/all-in-one:latest                   "/go/bin/all-in-one-…"   7 seconds ago   Up 5 seconds                      4317-4318/tcp, 9411/tcp, 0.0.0.0:14250->14250/tcp, :::14250->14250/tcp, 14268/tcp, 0.0.0.0:16686->16686/tcp, :::16686->16686/tcp          jaeger
 1897830a2f1e   otel/opentelemetry-collector-contrib:latest       "/otelcol-contrib --…"   7 seconds ago   Up 5 seconds                      0.0.0.0:4317-4318->4317-4318/tcp, :::4317-4318->4317-4318/tcp, 0.0.0.0:8888-8889->8888-8889/tcp, :::8888-8889->8888-8889/tcp, 55679/tcp   otel-collector
 ```
-
 If you only want to install RustFS without Grafana, Prometheus, and the other observability services, start just the `rustfs` service (the compose file marks the collector dependency as optional):
 
 ```bash
 docker compose -f docker-compose.yml up -d rustfs
 ```
-
 This way will only install and start `rustfs-server` service, namely rustfs container,
 
 ```text
@@ -234,7 +231,6 @@ docker ps
 CONTAINER ID   IMAGE                                             COMMAND                  CREATED         STATUS                           PORTS                                                           NAMES
 e07121ecdd39   rustfs/rustfs:latest                              "/entrypoint.sh rust…"   2 seconds ago   Up 1 second (health: starting)   0.0.0.0:9000-9001->9000-9001/tcp, :::9000-9001->9000-9001/tcp   rustfs-server
 ```
-
 Whether you start only the `rustfs-server` or together with observability services, the S3 API is served at `http://localhost:9000`, and the RustFS Console is at `http://localhost:9001` — open it in a browser and log in with the access key and secret key you configured above (the `<your-access-key>` / `<your-secret-key>` placeholders). Generate a strong secret with, for example, `openssl rand -base64 24`, and never ship the placeholder values to production.
 
 :::warning[Set container credentials immediately]
@@ -278,17 +274,17 @@ docker run -d \
   --name rustfs \
   --network host \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   -e RUSTFS_VOLUMES="http://node{1...4}:9000/data/rustfs{0...3}" \
   rustfs/rustfs:latest
 ```
-
 Add the entries to `/etc/hosts` on **every** node:
 ```ini title="/etc/hosts"
 192.168.1.1 node1
@@ -296,7 +292,6 @@ Add the entries to `/etc/hosts` on **every** node:
 192.168.1.3 node3
 192.168.1.4 node4
 ```
-
 ## 6. Other Recommendations
 
 1. Production Environment Recommendations:

--- a/content/ja/installation/container/podman.md
+++ b/content/ja/installation/container/podman.md
@@ -17,6 +17,11 @@ Create a named volume so object data remains available when you replace the cont
 
 ```bash
 podman volume create rustfs-data
+podman volume create rustfs-logs
+
+# Bind-mount alternative on SELinux hosts (`:U` sets ownership; `:Z` sets the SELinux label):
+# mkdir -p data logs
+# podman run ... -v "$(pwd)/data":/data:Z,U -v "$(pwd)/logs":/logs:Z,U ...
 ```
 
 ## 3. Start RustFS
@@ -29,13 +34,14 @@ podman run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v rustfs-data:/data \
+  -v rustfs-logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   docker.io/rustfs/rustfs:latest \
   /data
 ```
@@ -54,7 +60,6 @@ Check the container and the S3 API health endpoint:
 podman ps --filter name=rustfs
 curl --fail http://localhost:9000/health
 ```
-
 The S3 API is available at `http://localhost:9000`, and the Console is available at `http://localhost:9001`.
 
 ## Next steps

--- a/content/ja/operations/observability.md
+++ b/content/ja/operations/observability.md
@@ -12,14 +12,12 @@ RustFS (RUSTFS_OBS_ENDPOINT) --OTLP--> OpenTelemetry Collector --> Prometheus --
                                                               \--> Loki (logs)
                                                               \--> Tempo / Jaeger (traces)
 ```
-
 Point RustFS at the Collector with:
 
 ```bash
 # OTLP over HTTP (the Collector's default HTTP receiver port is 4318; gRPC is 4317)
 RUSTFS_OBS_ENDPOINT=http://otel-collector:4318
 ```
-
 Related environment variables (all defined in the server configuration):
 
 | Variable | Purpose |
@@ -53,7 +51,6 @@ service:
       receivers: [otlp]
       exporters: [prometheus]
 ```
-
 Prometheus then scrapes the Collector, not RustFS:
 
 ```yaml
@@ -66,7 +63,6 @@ scrape_configs:
     static_configs:
       - targets: ["otel-collector:8888"]   # Collector self-metrics
 ```
-
 :::note
 
 If Prometheus shows no `rustfs_*` series, check the chain in order: is `RUSTFS_OBS_ENDPOINT` set on every node, is the Collector reachable from the nodes, and is Prometheus scraping the Collector's `8889` exporter port.
@@ -219,6 +215,7 @@ RUSTFS_ADDRESS=":9000"
 RUSTFS_CONSOLE_ADDRESS=":9001"
 RUSTFS_CONSOLE_ENABLE=true
 RUSTFS_OBS_LOGGER_LEVEL=error
+# Linux packages use /var/log/rustfs/; the container image uses /logs.
 RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/"
 RUSTFS_OBS_ENDPOINT=http://otel-collector:4318
 ```

--- a/content/ja/operations/upgrade/container/index.md
+++ b/content/ja/operations/upgrade/container/index.md
@@ -28,17 +28,16 @@ The following workflow matches the container name and named volume used in the [
 Record the current image, then pull the target version:
 
 ```bash
+docker volume create rustfs-logs
 docker inspect --format '{{.Config.Image}}' rustfs
 docker pull rustfs/rustfs:<target-version>
 ```
-
 Stop and remove only the container. The `rustfs-data` volume remains intact:
 
 ```bash
 docker stop rustfs
 docker rm rustfs
 ```
-
 Recreate the container with the original configuration and the target image:
 
 ```bash
@@ -48,17 +47,17 @@ docker run -d \
 	-p 9000:9000 \
 	-p 9001:9001 \
 	-v rustfs-data:/data \
+	-v rustfs-logs:/logs \
 	-e RUSTFS_ACCESS_KEY="<your-access-key>" \
 	-e RUSTFS_SECRET_KEY="<your-secret-key>" \
 	-e RUSTFS_ADDRESS=":9000" \
 	-e RUSTFS_CONSOLE_ADDRESS=":9001" \
 	-e RUSTFS_CONSOLE_ENABLE=true \
 	-e RUSTFS_OBS_LOGGER_LEVEL=error \
-	-e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+	-e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
 	rustfs/rustfs:<target-version> \
 	/data
 ```
-
 Wait for the replacement container to become healthy:
 
 ```bash
@@ -72,12 +71,12 @@ curl -fsS http://localhost:9000/health/ready
 The Podman workflow is the same replacement operation, using the image name from the [Podman installation guide](/installation/container/podman).
 
 ```bash
+podman volume create rustfs-logs
 podman inspect --format '{{.Config.Image}}' rustfs
 podman pull docker.io/rustfs/rustfs:<target-version>
 podman stop rustfs
 podman rm rustfs
 ```
-
 Recreate the container with the original configuration and persistent volume:
 
 ```bash
@@ -86,17 +85,17 @@ podman run -d \
 	-p 9000:9000 \
 	-p 9001:9001 \
 	-v rustfs-data:/data \
+	-v rustfs-logs:/logs \
 	-e RUSTFS_ACCESS_KEY="<your-access-key>" \
 	-e RUSTFS_SECRET_KEY="<your-secret-key>" \
 	-e RUSTFS_ADDRESS=":9000" \
 	-e RUSTFS_CONSOLE_ADDRESS=":9001" \
 	-e RUSTFS_CONSOLE_ENABLE=true \
 	-e RUSTFS_OBS_LOGGER_LEVEL=error \
-	-e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+	-e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
 	docker.io/rustfs/rustfs:<target-version> \
 	/data
 ```
-
 Verify the replacement before continuing:
 
 ```bash
@@ -113,7 +112,6 @@ Run Compose commands from the directory containing the deployment's `docker-comp
 docker compose config > docker-compose.resolved.yaml
 docker compose images rustfs
 ```
-
 Change the `rustfs` service to an explicit target image tag while leaving its volumes, environment, ports, and command unchanged:
 
 ```yaml title="docker-compose.yml"
@@ -121,7 +119,6 @@ services:
 	rustfs:
 		image: rustfs/rustfs:<target-version>
 ```
-
 Validate the file, pull the target image, and recreate only the RustFS service. `--no-deps` leaves optional observability services running:
 
 ```bash
@@ -129,7 +126,6 @@ docker compose config --quiet
 docker compose pull rustfs
 docker compose up -d --no-deps rustfs
 ```
-
 Check the service and the RustFS readiness endpoint:
 
 ```bash
@@ -137,7 +133,6 @@ docker compose ps rustfs
 docker compose logs --tail=100 rustfs
 curl -fsS http://localhost:9000/health/ready
 ```
-
 If you started RustFS together with the `observability` profile, the RustFS service still upgrades with the same commands. Upgrade observability images separately according to each component's release notes.
 
 ## Upgrade a multi-node deployment
@@ -157,7 +152,6 @@ docker compose pull rustfs
 docker compose up -d --no-deps rustfs
 curl -fsS http://localhost:9000/health/ready
 ```
-
 In a multi-node deployment, roll back one node at a time and wait for readiness before continuing.
 
 ## Next steps

--- a/content/zh/developer/integration/big-data/iceberg.md
+++ b/content/zh/developer/integration/big-data/iceberg.md
@@ -33,14 +33,12 @@ Spark 使用 REST 服务执行 catalog 操作。Spark 和 REST catalog 都会接
 mkdir rustfs-iceberg
 cd rustfs-iceberg
 ```
-
 创建环境文件并替换两个凭证占位符：
 
 ```ini title=".env"
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 请为仓库存储桶使用专用凭证。不要将 `.env` 提交到源代码管理系统。
 
 创建 Spark catalog 配置：
@@ -57,7 +55,6 @@ spark.sql.catalog.demo.s3.path-style-access true
 spark.sql.defaultCatalog demo
 spark.sql.catalogImplementation in-memory
 ```
-
 此容器网络端点必须使用路径样式访问。主机名 `rustfs` 只能在 Compose 网络内部解析；在主机上运行的客户端应改用 `http://localhost:9000`。
 
 创建 Compose 文件：
@@ -74,7 +71,7 @@ services:
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     volumes:
       - rustfs-data:/data
     ports:
@@ -145,7 +142,6 @@ networks:
 volumes:
   rustfs-data:
 ```
-
 [`rc` 镜像](https://github.com/rustfs/cli)提供官方 RustFS 命令行客户端。初始化程序会在创建 `my-bucket` 前检查其是否存在，因此重复启动不会删除现有仓库数据。RustFS 卷会在容器重新创建后继续保留仓库对象。
 
 :::warning[镜像版本]
@@ -161,20 +157,17 @@ Apache Iceberg 快速入门镜像在上游示例中发布时没有稳定版本�
 ```bash
 docker compose config
 ```
-
 启动服务并等待存储桶初始化程序完成：
 
 ```bash
 docker compose up -d
 docker compose ps -a
 ```
-
 `create-bucket` 服务应显示退出代码 `0`。如果该服务未完成，请检查其日志：
 
 ```bash
 docker compose logs create-bucket
 ```
-
 在 `http://localhost:9001` 打开 RustFS 控制台。REST catalog 位于 `http://localhost:8181`，Spark notebook 服务器位于 `http://localhost:8888`。
 
 ## 3. 创建并查询 Iceberg 表
@@ -184,7 +177,6 @@ docker compose logs create-bucket
 ```bash
 docker compose exec spark-iceberg spark-sql
 ```
-
 创建命名空间和分区表：
 
 ```sql
@@ -200,7 +192,6 @@ CREATE TABLE demo.nyc.taxis
 )
 PARTITIONED BY (vendor_id);
 ```
-
 插入并查询示例数据行：
 
 ```sql
@@ -213,7 +204,6 @@ VALUES
 
 SELECT * FROM demo.nyc.taxis ORDER BY trip_id;
 ```
-
 查询应返回四行：
 
 ```text
@@ -222,7 +212,6 @@ SELECT * FROM demo.nyc.taxis ORDER BY trip_id;
 2  1000373  0.9  9.01   N
 1  1000374  8.4  42.13  Y
 ```
-
 ## 4. 验证 RustFS 中的对象
 
 使用存储桶初始化程序镜像列出仓库内容：
@@ -231,7 +220,6 @@ SELECT * FROM demo.nyc.taxis ORDER BY trip_id;
 docker compose run --rm --entrypoint /bin/sh create-bucket -c \
   '/usr/bin/rc alias set rustfs http://rustfs:9000 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY" >/dev/null && /usr/bin/rc find rustfs/my-bucket/warehouse'
 ```
-
 输出应包含 `warehouse/nyc/taxis` 前缀下的 Iceberg 元数据和数据对象。你也可以在 RustFS 控制台中检查 `my-bucket` 存储桶。
 
 ## 5. 停止或重置服务栈
@@ -241,13 +229,11 @@ docker compose run --rm --entrypoint /bin/sh create-bucket -c \
 ```bash
 docker compose down
 ```
-
 要删除本地仓库并从空的 RustFS 卷重新开始，请显式添加 `--volumes`：
 
 ```bash
 docker compose down --volumes
 ```
-
 ## 故障排除
 
 ### Spark 无法连接 RustFS
@@ -263,7 +249,6 @@ docker compose down --volumes
 ```bash
 docker compose logs create-bucket rest
 ```
-
 REST catalog 属性 `CATALOG_IO__IMPL` 和 `CATALOG_S3_PATH__STYLE__ACCESS` 使用双下划线；fixture 会将它们转换为带点号和连字符的 Iceberg 属性名。
 
 ## 后续步骤

--- a/content/zh/developer/integration/big-data/milvus.md
+++ b/content/zh/developer/integration/big-data/milvus.md
@@ -34,14 +34,12 @@ Milvus 将服务元数据存储在 etcd 中，并将向量数据、索引和相�
 mkdir rustfs-milvus
 cd rustfs-milvus
 ```
-
 创建环境文件并替换两个凭证占位符：
 
 ```ini title=".env"
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 请为 Milvus 存储桶使用专用凭证。不要将 `.env` 提交到源代码管理系统。
 
 创建 Milvus 存储覆盖配置：
@@ -61,7 +59,6 @@ minio:
   region: us-east-1
   useVirtualHost: false
 ```
-
 `useVirtualHost: false` 会选择路径样式 S3 请求。主机名 `rustfs` 可在 Compose 网络内部解析；主机上的客户端使用 `http://localhost:9000`。
 
 创建 Compose 文件：
@@ -100,7 +97,7 @@ services:
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     volumes:
       - rustfs-data:/data
     ports:
@@ -185,7 +182,6 @@ volumes:
   rustfs-data:
   milvus-data:
 ```
-
 `create-bucket` 服务使用官方 [`rc`](https://github.com/rustfs/cli) 镜像，并在确保 `my-bucket` 存在后退出。命名卷会在容器重新创建时保留 etcd 元数据、RustFS 对象和 Milvus 本地数据。
 
 :::warning[保护本地服务端口]
@@ -201,20 +197,17 @@ volumes:
 ```bash
 docker compose config
 ```
-
 启动服务：
 
 ```bash
 docker compose up -d
 docker compose ps -a
 ```
-
 `create-bucket` 服务应以代码 `0` 退出，`etcd`、`rustfs` 和 `standalone` 应进入健康状态。如果服务未达到预期状态，请检查日志：
 
 ```bash
 docker compose logs create-bucket rustfs standalone
 ```
-
 打开以下本地界面：
 
 - RustFS 控制台：`http://localhost:9001`
@@ -232,7 +225,6 @@ python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install "pymilvus==2.6.0"
 ```
-
 创建测试脚本：
 
 ```python title="verify_milvus.py"
@@ -269,13 +261,11 @@ results = client.search(
 print(results)
 client.close()
 ```
-
 运行脚本：
 
 ```bash
 python verify_milvus.py
 ```
-
 结果应将 ID 为 `1` 的数据行排在第一位。打开 Attu 并确认 `rustfs_demo` collection 包含三个实体。
 
 ## 4. 验证 RustFS 中的 Milvus 对象
@@ -286,7 +276,6 @@ python verify_milvus.py
 docker compose run --rm --entrypoint /bin/sh create-bucket -c \
   '/usr/bin/rc alias set rustfs http://rustfs:9000 "$RUSTFS_ACCESS_KEY" "$RUSTFS_SECRET_KEY" --region us-east-1 --bucket-lookup path >/dev/null && /usr/bin/rc find rustfs/my-bucket/milvus'
 ```
-
 输出应包含 Milvus 在 `milvus/` 前缀下创建的对象。你也可以在 RustFS 控制台中打开 `my-bucket`。
 
 Milvus 可能会在每个预期对象出现前缓冲或压缩数据。插入、刷新和查询成功，再加上 RustFS 对象列表，共同验证了集成路径。
@@ -298,13 +287,11 @@ Milvus 可能会在每个预期对象出现前缓冲或压缩数据。插入、�
 ```bash
 docker compose down
 ```
-
 要删除本地测试数据（包括 Milvus 存储桶内容和 etcd 元数据），请显式移除卷：
 
 ```bash
 docker compose down --volumes
 ```
-
 :::warning[重置会删除测试数据]
 
 `--volumes` 选项会永久删除此 Compose 项目使用的命名卷。请勿针对需要保留的数据运行此命令。
@@ -322,7 +309,6 @@ docker compose down --volumes
 ```bash
 docker compose logs standalone rustfs
 ```
-
 ### 存储桶初始化程序失败
 
 检查 RustFS 就绪状态和初始化程序日志：
@@ -331,7 +317,6 @@ docker compose logs standalone rustfs
 curl -fsS http://localhost:9000/health/ready
 docker compose logs create-bucket
 ```
-
 确认 `.env` 包含非空凭证，并且 `docker compose config` 能够解析这两个变量。
 
 ### Milvus 启动后没有现有数据
@@ -346,7 +331,6 @@ Attu 容器必须使用 `standalone:19530`。浏览器或主机端客户端应�
 curl -fsS http://localhost:9091/healthz
 docker compose logs attu standalone
 ```
-
 ## 后续步骤
 
 - 在启用其他 Milvus 存储功能前，请查看 [S3 兼容性说明](/administration/protocols/s3)。

--- a/content/zh/developer/integration/reverse-proxy/caddy.md
+++ b/content/zh/developer/integration/reverse-proxy/caddy.md
@@ -26,7 +26,6 @@ description: "在 Caddy 后方部署 RustFS，并为独立的 S3 API 和控制�
 mkdir rustfs-caddy
 cd rustfs-caddy
 ```
-
 ## 2. 设置部署变量
 
 创建环境文件并替换每个值：
@@ -38,7 +37,6 @@ ACME_EMAIL=admin@example.com
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 请使用能够接收证书通知的电子邮件地址。不要将 `.env` 提交到源代码管理系统。
 
 ## 3. 配置 Caddy
@@ -72,7 +70,6 @@ RUSTFS_SECRET_KEY=<your-secret-key>
 		}
 }
 ```
-
 Caddy 默认会保留传入的 `Host` 标头、HTTP 方法和请求 URI。它还会通过 `X-Forwarded-*` 标头转发客户端信息，并且无需额外的标头规则即可处理控制台 WebSocket 升级。
 
 ## 4. 创建 Compose 文件
@@ -112,7 +109,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -135,7 +132,6 @@ volumes:
 networks:
   rustfs:
 ```
-
 持久化的 `caddy-data` 卷用于存储证书、私钥和 ACME 账户状态。请备份此卷，并且不要共享其中的内容。只有 Caddy 会发布主机端口；RustFS 仅可在 Compose 网络内部访问。
 
 ## 5. 验证并启动部署
@@ -146,13 +142,11 @@ networks:
 docker compose config
 docker compose up -d rustfs
 ```
-
 使用与部署相同的镜像验证 Caddyfile：
 
 ```bash
 docker compose run --rm --no-deps caddy caddy validate --config /etc/caddy/Caddyfile
 ```
-
 启动 Caddy 并检查两个服务：
 
 ```bash
@@ -160,7 +154,6 @@ docker compose up -d caddy
 docker compose ps
 docker compose logs --follow caddy
 ```
-
 Caddy 会在后台获取证书，并将 HTTP 请求重定向到 HTTPS。如果签发失败，请确认两条 DNS 记录均解析到此主机、端口 `80` 和 `443` 可以访问，并且 `caddy-data` 卷可写。
 
 ## 6. 验证两个端点
@@ -171,7 +164,6 @@ Caddy 会在后台获取证书，并将 HTTP 请求重定向到 HTTPS。如果�
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 将 S3 客户端端点配置为 `https://s3.example.com`，并启用路径样式寻址。打开 `https://console.example.com` 登录控制台。
 
 ## 多节点上游
@@ -199,7 +191,6 @@ curl --fail https://console.example.com/rustfs/console/health
 		}
 }
 ```
-
 将 `<your-cookie-secret>` 替换为由所有 Caddy 实例共享的随机密钥。控制台会话亲和性可确保正在进行的 OpenID Connect 登录始终由创建其 `state` 的 RustFS 节点处理。请保持 RustFS 节点之间的端口 `9000` 直接开放，因为内部节点 RPC 使用同一监听器。
 
 ## 后续步骤

--- a/content/zh/developer/integration/reverse-proxy/haproxy.md
+++ b/content/zh/developer/integration/reverse-proxy/haproxy.md
@@ -26,14 +26,12 @@ description: "在 HAProxy 后方部署 RustFS，为 S3 API 和控制台配置独
 mkdir -p rustfs-haproxy/config rustfs-haproxy/certs
 cd rustfs-haproxy
 ```
-
 HAProxy 要求证书链和私钥位于同一个 PEM 文件中。请按以下顺序合并：
 
 ```bash
 cat fullchain.pem privkey.pem > certs/rustfs.pem
 chmod 600 certs/rustfs.pem
 ```
-
 证书必须涵盖两个公网主机名。
 
 ## 2. 设置 RustFS 凭证
@@ -44,7 +42,6 @@ chmod 600 certs/rustfs.pem
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 不要将此文件或证书私钥提交到源代码管理系统。
 
 ## 3. 配置 HAProxy
@@ -95,7 +92,6 @@ backend rustfs_console
     http-check expect status 200
     server rustfs rustfs:9001 check inter 10s fall 3 rise 2 cookie rustfs
 ```
-
 除非显式重写，否则 HAProxy 会保留传入的主机和请求路径。较长的客户端、服务器和隧道超时时间可以满足流式 S3 操作和控制台 WebSocket 连接的需要。
 
 控制台后端会设置亲和性 Cookie。只有一台 RustFS 服务器时，它不会影响路由，但保留在基础配置中可以使添加节点后的行为保持一致。
@@ -131,7 +127,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -152,7 +148,6 @@ volumes:
 networks:
   rustfs:
 ```
-
 只有 HAProxy 会发布主机端口。RustFS 端口 `9000` 和 `9001` 仅可在 Compose 网络内部访问。
 
 ## 5. 验证并启动部署
@@ -163,27 +158,23 @@ networks:
 docker compose config
 docker compose up -d rustfs
 ```
-
 使用与部署相同的镜像验证 HAProxy 配置：
 
 ```bash
 docker compose run --rm --no-deps haproxy haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg
 ```
-
 启动 HAProxy 并检查两个服务：
 
 ```bash
 docker compose up -d haproxy
 docker compose ps
 ```
-
 如果服务未进入健康状态，请检查其日志：
 
 ```bash
 docker compose logs haproxy
 docker compose logs rustfs
 ```
-
 ## 6. 验证两个端点
 
 通过各自的公网 HTTPS 主机名验证 API 和控制台：
@@ -192,7 +183,6 @@ docker compose logs rustfs
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 将 S3 客户端端点配置为 `https://s3.example.com`，并启用路径样式寻址。打开 `https://console.example.com` 登录控制台。
 
 替换续订后的 `certs/rustfs.pem` 时，请验证配置并重新创建 HAProxy 容器以加载证书：
@@ -201,7 +191,6 @@ curl --fail https://console.example.com/rustfs/console/health
 docker compose run --rm --no-deps haproxy haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg
 docker compose up -d --force-recreate haproxy
 ```
-
 ## 多节点后端
 
 对于分布式 RustFS 部署，请将每个 RustFS 节点添加到两个后端：
@@ -226,7 +215,6 @@ backend rustfs_console
 		server node3 node3.example.net:9001 check inter 10s fall 3 rise 2 cookie node3
 		server node4 node4.example.net:9001 check inter 10s fall 3 rise 2 cookie node4
 ```
-
 控制台 Cookie 可确保正在进行的 OpenID Connect 登录始终由创建其 `state` 的 RustFS 节点处理。请保持 RustFS 节点之间的端口 `9000` 直接开放，因为内部节点 RPC 使用同一监听器。
 
 ## 后续步骤

--- a/content/zh/developer/integration/reverse-proxy/nginx.md
+++ b/content/zh/developer/integration/reverse-proxy/nginx.md
@@ -26,7 +26,6 @@ description: "在 Nginx 后方部署 RustFS，为 S3 API 和控制台配置独�
 mkdir -p rustfs-nginx/sites rustfs-nginx/certs
 cd rustfs-nginx
 ```
-
 将证书链和私钥复制到 `certs/`：
 
 ```text
@@ -36,13 +35,11 @@ rustfs-nginx/
 │   └── privkey.pem
 └── sites/
 ```
-
 限制对私钥的访问：
 
 ```bash
 chmod 600 certs/privkey.pem
 ```
-
 ## 2. 设置 RustFS 凭证
 
 创建环境文件并替换两个凭证占位符：
@@ -51,7 +48,6 @@ chmod 600 certs/privkey.pem
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 不要将此文件提交到源代码管理系统。
 
 ## 3. 配置 Nginx
@@ -136,7 +132,6 @@ server {
     }
 }
 ```
-
 S3 服务器会保留原始主机和请求路径，禁用请求缓冲以支持流式上传，并且不会转换已签名的 `HEAD` 请求。控制台服务器还会转发 WebSocket 升级标头。
 
 ## 4. 创建 Compose 文件
@@ -170,7 +165,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -191,7 +186,6 @@ volumes:
 networks:
   rustfs:
 ```
-
 只有 Nginx 会发布主机端口。RustFS 端口 `9000` 和 `9001` 仅可在 Compose 网络内部访问。
 
 ## 5. 验证并启动部署
@@ -203,21 +197,18 @@ docker compose config
 docker compose up -d rustfs
 docker compose run --rm --no-deps nginx nginx -t
 ```
-
 启动 Nginx 并检查两个服务：
 
 ```bash
 docker compose up -d nginx
 docker compose ps
 ```
-
 如果服务未进入健康状态，请检查其日志：
 
 ```bash
 docker compose logs nginx
 docker compose logs rustfs
 ```
-
 ## 6. 验证两个端点
 
 通过各自的公网 HTTPS 主机名验证 API 和控制台：
@@ -226,7 +217,6 @@ docker compose logs rustfs
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 将 S3 客户端端点配置为 `https://s3.example.com`，并启用路径样式寻址。打开 `https://console.example.com` 登录控制台。
 
 替换 `certs/` 中续订后的证书或密钥时，请验证配置并重新加载 Nginx，且不会中断活动连接：
@@ -235,7 +225,6 @@ curl --fail https://console.example.com/rustfs/console/health
 docker compose exec nginx nginx -t
 docker compose exec nginx nginx -s reload
 ```
-
 ## 多节点上游
 
 对于分布式 RustFS 部署，请将每个上游中的单台服务器替换为所有 RustFS 节点：
@@ -259,7 +248,6 @@ upstream rustfs_console {
   keepalive 16;
 }
 ```
-
 控制台上游使用客户端亲和性，因为正在进行的 OpenID Connect 登录会将其 `state` 存储在一个 RustFS 节点上。请保持 RustFS 节点之间的端口 `9000` 开放，因为内部节点 RPC 使用同一监听器。
 
 ## 后续步骤

--- a/content/zh/developer/integration/reverse-proxy/traefik.md
+++ b/content/zh/developer/integration/reverse-proxy/traefik.md
@@ -28,7 +28,6 @@ cd rustfs-traefik
 touch acme.json
 chmod 600 acme.json
 ```
-
 ## 2. 设置部署变量
 
 创建环境文件并替换每个值：
@@ -40,7 +39,6 @@ ACME_EMAIL=admin@example.com
 RUSTFS_ACCESS_KEY=<your-access-key>
 RUSTFS_SECRET_KEY=<your-secret-key>
 ```
-
 请使用能够接收证书到期通知的电子邮件地址。不要将 `.env` 或 `acme.json` 提交到源代码管理系统。
 
 ## 3. 创建 Compose 文件
@@ -86,7 +84,7 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
       RUSTFS_OBS_LOGGER_LEVEL: error
-      RUSTFS_OBS_LOG_DIRECTORY: /var/log/rustfs/
+      RUSTFS_OBS_LOG_DIRECTORY: /logs
     expose:
       - "9000"
       - "9001"
@@ -125,7 +123,6 @@ networks:
   rustfs:
     name: rustfs
 ```
-
 两个路由器使用不同的主机规则和后端端口。RustFS 不会在 Docker 主机上发布端口 `9000` 或 `9001`，Traefik Dashboard 也不会对外公开。
 
 :::note[Docker 套接字访问]
@@ -141,20 +138,17 @@ Traefik 通过只读 Docker 套接字挂载读取容器标签。任何能够修�
 ```bash
 docker compose config
 ```
-
 启动两个服务：
 
 ```bash
 docker compose up -d
 docker compose ps
 ```
-
 在 Traefik 完成 ACME 质询并创建两张证书期间跟踪其日志：
 
 ```bash
 docker compose logs --follow traefik
 ```
-
 如果证书签发失败，请确认两条 DNS 记录均解析到此主机，并且端口 `80` 和 `443` 可从互联网访问。Let's Encrypt 存在速率限制，因此请先修正 DNS 和防火墙问题，再反复重新创建部署。
 
 ## 5. 验证两个端点
@@ -165,7 +159,6 @@ docker compose logs --follow traefik
 curl --fail https://s3.example.com/health/ready
 curl --fail https://console.example.com/rustfs/console/health
 ```
-
 将 S3 客户端端点配置为 `https://s3.example.com`，并启用路径样式寻址。打开 `https://console.example.com` 登录控制台。
 
 ## 多节点服务
@@ -181,7 +174,6 @@ services:
     volumes:
       - ./dynamic.yaml:/etc/traefik/dynamic.yaml:ro
 ```
-
 创建包含每个 RustFS 节点的动态配置：
 
 ```yaml title="dynamic.yaml"
@@ -233,7 +225,6 @@ http:
           - url: http://node3.example.net:9001
           - url: http://node4.example.net:9001
 ```
-
 使用 OpenID Connect 时，请为控制台服务配置粘性会话。正在进行的登录会将其 `state` 存储在一个 RustFS 节点上，回调必须返回该节点。请保持 RustFS 节点之间的端口 `9000` 直接开放，因为内部节点 RPC 使用同一监听器。
 
 ## 后续步骤

--- a/content/zh/installation/container/docker.md
+++ b/content/zh/installation/container/docker.md
@@ -17,6 +17,11 @@ docker pull rustfs/rustfs:latest
 
 ```bash
 docker volume create rustfs-data
+docker volume create rustfs-logs
+
+# Bind-mount alternative (host directories must be owned by 10001:10001):
+# mkdir -p data logs
+# sudo chown -R 10001:10001 data logs
 ```
 
 ## 3. 启动 RustFS
@@ -30,13 +35,14 @@ docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v rustfs-data:/data \
+  -v rustfs-logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   rustfs/rustfs:latest \
   /data
 ```
@@ -55,7 +61,6 @@ docker run -d \
 docker ps --filter name=rustfs
 curl --fail http://localhost:9000/health
 ```
-
 S3 API 位于 `http://localhost:9000`，控制台位于 `http://localhost:9001`。
 
 ## 后续步骤

--- a/content/zh/installation/container/index.mdx
+++ b/content/zh/installation/container/index.mdx
@@ -32,7 +32,6 @@ RustFS 是高性能、兼容 S3 的开源分布式对象存储系统。在单节
 ```bash
 docker pull rustfs/rustfs
 ```
-
 ---
 
 
@@ -47,10 +46,10 @@ docker pull rustfs/rustfs
   -p 9000:9000 \
   -p 9001:9001 \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   rustfs/rustfs:latest \
   /data
 ```
-
 参数说明：
 
 * `-p 9000:9000`：将主机端口 9000 映射到容器
@@ -67,27 +66,6 @@ docker pull rustfs/rustfs
 <Tabs items={["Environment variables", "Command-line flags"]}>
   <Tab value="Environment variables" id="docker-env-config">
 
-```bash {7,8}
-# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
-docker run -d \
-  --name rustfs \
-  -p 9000:9000 \
-  -p 9001:9001 \
-  -v /mnt/rustfs/data:/data \
-  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
-  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
-  -e RUSTFS_ADDRESS=":9000" \
-  -e RUSTFS_CONSOLE_ADDRESS=":9001" \
-  -e RUSTFS_CONSOLE_ENABLE=true \
-  -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
-  rustfs/rustfs:latest \
-  /data
-```
-
-  </Tab>
-  <Tab value="Command-line flags" id="docker-cli-config">
-
 ```bash {8,9}
 # Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
 docker run -d \
@@ -95,6 +73,28 @@ docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
+  -e RUSTFS_ACCESS_KEY="<your-access-key>" \
+  -e RUSTFS_SECRET_KEY="<your-secret-key>" \
+  -e RUSTFS_ADDRESS=":9000" \
+  -e RUSTFS_CONSOLE_ADDRESS=":9001" \
+  -e RUSTFS_CONSOLE_ENABLE=true \
+  -e RUSTFS_OBS_LOGGER_LEVEL=error \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
+  rustfs/rustfs:latest \
+  /data
+```
+  </Tab>
+  <Tab value="Command-line flags" id="docker-cli-config">
+
+```bash {9,10}
+# Use a unique access key and a strong, random secret (e.g. openssl rand -base64 24)
+docker run -d \
+  --name rustfs \
+  -p 9000:9000 \
+  -p 9001:9001 \
+  -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   rustfs/rustfs:latest \
   --access-key "<your-access-key>" \
   --secret-key "<your-secret-key>" \
@@ -102,7 +102,6 @@ docker run -d \
   --console-enable \
   /data
 ```
-
   </Tab>
 </Tabs>
 
@@ -114,6 +113,7 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
      rustfs/rustfs:latest \
      /data
    ```
@@ -124,11 +124,12 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
     -e RUSTFS_ADDRESS=":9000" \
     -e RUSTFS_CONSOLE_ADDRESS=":9001" \
     -e RUSTFS_CONSOLE_ENABLE=true \
     -e RUSTFS_OBS_LOGGER_LEVEL=error \
-    -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+    -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
      rustfs/rustfs:latest \
      --console-enable \
      /data
@@ -141,6 +142,7 @@ docker run -d \
      -p 9000:9000 \
      -p 9001:9001 \
      -v /mnt/data:/data \
+     -v /mnt/logs:/logs \
      -e RUSTFS_ACCESS_KEY="<your-access-key>" \
      -e RUSTFS_SECRET_KEY="<your-secret-key>" \
      rustfs/rustfs:latest \
@@ -173,13 +175,11 @@ RustFS 官方提供 Docker Compose 安装方式。[`docker-compose.yml`](https:/
 ```bash
 git clone https://github.com/rustfs/rustfs.git
 ```
-
 在根目录下运行命令：
 
 ```bash
 docker compose --profile observability up -d
 ```
-
 提供必要的权限。需要使用初始化容器，通过 `depends_on` 关键字为 rustfs 授予正确的访问权限。以下示例将 `rustfs_perms` 服务添加到 `docker-compose.yml` 来处理权限。为了确保日志持久化且可访问，将主机日志目录映射到容器的 `/var/log/rustfs/` 路径：
 
 ```yaml title="docker-compose.yml"
@@ -199,17 +199,16 @@ docker compose --profile observability up -d
           condition: service_completed_successfully
       volumes:
         - /path/to_host_directory/volumes/data:/data
-        - /path/to_host_directory/volumes/logs:/var/log/rustfs/
+        - /path/to_host_directory/volumes/logs:/logs
       environment:
         - RUSTFS_ADDRESS=":9000"
         - RUSTFS_CONSOLE_ADDRESS=":9001"
         - RUSTFS_CONSOLE_ENABLE=true
         - RUSTFS_OBS_LOGGER_LEVEL=error
-        - RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/"
+        - RUSTFS_OBS_LOG_DIRECTORY="/logs"
     
       # ... other configurations
 ```
-
 启动后的容器如下：
 
 ```text
@@ -220,13 +219,11 @@ e3f4fc4a83a2   grafana/grafana:latest                            "/run.sh"      
 e7db806b2d6f   jaegertracing/all-in-one:latest                   "/go/bin/all-in-one-…"   7 seconds ago   Up 5 seconds                      4317-4318/tcp, 9411/tcp, 0.0.0.0:14250->14250/tcp, :::14250->14250/tcp, 14268/tcp, 0.0.0.0:16686->16686/tcp, :::16686->16686/tcp          jaeger
 1897830a2f1e   otel/opentelemetry-collector-contrib:latest       "/otelcol-contrib --…"   7 seconds ago   Up 5 seconds                      0.0.0.0:4317-4318->4317-4318/tcp, :::4317-4318->4317-4318/tcp, 0.0.0.0:8888-8889->8888-8889/tcp, :::8888-8889->8888-8889/tcp, 55679/tcp   otel-collector
 ```
-
 如果只想安装 RustFS，而不安装 Grafana、Prometheus 和其他可观测性服务，请仅启动 `rustfs` 服务（compose 文件将 collector 依赖项标记为可选）：
 
 ```bash
 docker compose -f docker-compose.yml up -d rustfs
 ```
-
 这样只会安装并启动 `rustfs-server` 服务，即 rustfs 容器：
 
 ```text
@@ -234,7 +231,6 @@ docker ps
 CONTAINER ID   IMAGE                                             COMMAND                  CREATED         STATUS                           PORTS                                                           NAMES
 e07121ecdd39   rustfs/rustfs:latest                              "/entrypoint.sh rust…"   2 seconds ago   Up 1 second (health: starting)   0.0.0.0:9000-9001->9000-9001/tcp, :::9000-9001->9000-9001/tcp   rustfs-server
 ```
-
 无论只启动 `rustfs-server` 还是同时启动可观测性服务，S3 API 都位于 `http://localhost:9000`，RustFS 控制台位于 `http://localhost:9001`。请在浏览器中打开控制台，使用上面配置的访问密钥和秘密密钥（`<your-access-key>` / `<your-secret-key>` 占位符）登录。例如使用 `openssl rand -base64 24` 生成强密钥，绝不要将占位符值用于生产环境。
 
 :::warning[立即设置容器凭证]
@@ -278,17 +274,17 @@ docker run -d \
   --name rustfs \
   --network host \
   -v /mnt/rustfs/data:/data \
+  -v /mnt/rustfs/logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   -e RUSTFS_VOLUMES="http://node{1...4}:9000/data/rustfs{0...3}" \
   rustfs/rustfs:latest
 ```
-
 在**每个**节点的 `/etc/hosts` 中添加条目：
 ```ini title="/etc/hosts"
 192.168.1.1 node1
@@ -296,7 +292,6 @@ docker run -d \
 192.168.1.3 node3
 192.168.1.4 node4
 ```
-
 ## 6. 其他建议
 
 1. 生产环境建议：

--- a/content/zh/installation/container/podman.md
+++ b/content/zh/installation/container/podman.md
@@ -17,6 +17,11 @@ podman pull docker.io/rustfs/rustfs:latest
 
 ```bash
 podman volume create rustfs-data
+podman volume create rustfs-logs
+
+# Bind-mount alternative on SELinux hosts (`:U` sets ownership; `:Z` sets the SELinux label):
+# mkdir -p data logs
+# podman run ... -v "$(pwd)/data":/data:Z,U -v "$(pwd)/logs":/logs:Z,U ...
 ```
 
 ## 3. 启动 RustFS
@@ -29,13 +34,14 @@ podman run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   -v rustfs-data:/data \
+  -v rustfs-logs:/logs \
   -e RUSTFS_ACCESS_KEY="<your-access-key>" \
   -e RUSTFS_SECRET_KEY="<your-secret-key>" \
   -e RUSTFS_ADDRESS=":9000" \
   -e RUSTFS_CONSOLE_ADDRESS=":9001" \
   -e RUSTFS_CONSOLE_ENABLE=true \
   -e RUSTFS_OBS_LOGGER_LEVEL=error \
-  -e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+  -e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
   docker.io/rustfs/rustfs:latest \
   /data
 ```
@@ -54,7 +60,6 @@ podman run -d \
 podman ps --filter name=rustfs
 curl --fail http://localhost:9000/health
 ```
-
 S3 API 位于 `http://localhost:9000`，控制台位于 `http://localhost:9001`。
 
 ## 后续步骤

--- a/content/zh/operations/observability.md
+++ b/content/zh/operations/observability.md
@@ -12,14 +12,12 @@ RustFS (RUSTFS_OBS_ENDPOINT) --OTLP--> OpenTelemetry Collector --> Prometheus --
                                                               \--> Loki (logs)
                                                               \--> Tempo / Jaeger (traces)
 ```
-
 使用以下配置将 RustFS 指向 Collector：
 
 ```bash
 # OTLP over HTTP (the Collector's default HTTP receiver port is 4318; gRPC is 4317)
 RUSTFS_OBS_ENDPOINT=http://otel-collector:4318
 ```
-
 相关环境变量（均在服务器配置中定义）：
 
 | 变量 | 用途 |
@@ -53,7 +51,6 @@ service:
       receivers: [otlp]
       exporters: [prometheus]
 ```
-
 随后 Prometheus 抓取 Collector，而不是 RustFS：
 
 ```yaml
@@ -66,7 +63,6 @@ scrape_configs:
     static_configs:
       - targets: ["otel-collector:8888"]   # Collector self-metrics
 ```
-
 :::note
 
 如果 Prometheus 中没有 `rustfs_*` 序列，请依次检查：是否在每个节点上设置了 `RUSTFS_OBS_ENDPOINT`、节点能否访问 Collector，以及 Prometheus 是否正在抓取 Collector 的 `8889` 导出端口。
@@ -219,6 +215,7 @@ RUSTFS_ADDRESS=":9000"
 RUSTFS_CONSOLE_ADDRESS=":9001"
 RUSTFS_CONSOLE_ENABLE=true
 RUSTFS_OBS_LOGGER_LEVEL=error
+# Linux packages use /var/log/rustfs/; the container image uses /logs.
 RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/"
 RUSTFS_OBS_ENDPOINT=http://otel-collector:4318
 ```

--- a/content/zh/operations/upgrade/container/index.md
+++ b/content/zh/operations/upgrade/container/index.md
@@ -28,17 +28,16 @@ curl -fsS http://localhost:9000/health/ready
 记录当前镜像，然后拉取目标版本：
 
 ```bash
+docker volume create rustfs-logs
 docker inspect --format '{{.Config.Image}}' rustfs
 docker pull rustfs/rustfs:<target-version>
 ```
-
 仅停止并删除容器。`rustfs-data` 卷会保持不变：
 
 ```bash
 docker stop rustfs
 docker rm rustfs
 ```
-
 使用原始配置和目标镜像重新创建容器：
 
 ```bash
@@ -48,17 +47,17 @@ docker run -d \
 	-p 9000:9000 \
 	-p 9001:9001 \
 	-v rustfs-data:/data \
+	-v rustfs-logs:/logs \
 	-e RUSTFS_ACCESS_KEY="<your-access-key>" \
 	-e RUSTFS_SECRET_KEY="<your-secret-key>" \
 	-e RUSTFS_ADDRESS=":9000" \
 	-e RUSTFS_CONSOLE_ADDRESS=":9001" \
 	-e RUSTFS_CONSOLE_ENABLE=true \
 	-e RUSTFS_OBS_LOGGER_LEVEL=error \
-	-e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+	-e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
 	rustfs/rustfs:<target-version> \
 	/data
 ```
-
 等待替换容器进入健康状态：
 
 ```bash
@@ -72,12 +71,12 @@ curl -fsS http://localhost:9000/health/ready
 Podman 工作流程执行相同的替换操作，并使用 [Podman 安装指南](/installation/container/podman)中的镜像名称。
 
 ```bash
+podman volume create rustfs-logs
 podman inspect --format '{{.Config.Image}}' rustfs
 podman pull docker.io/rustfs/rustfs:<target-version>
 podman stop rustfs
 podman rm rustfs
 ```
-
 使用原始配置和持久化卷重新创建容器：
 
 ```bash
@@ -86,17 +85,17 @@ podman run -d \
 	-p 9000:9000 \
 	-p 9001:9001 \
 	-v rustfs-data:/data \
+	-v rustfs-logs:/logs \
 	-e RUSTFS_ACCESS_KEY="<your-access-key>" \
 	-e RUSTFS_SECRET_KEY="<your-secret-key>" \
 	-e RUSTFS_ADDRESS=":9000" \
 	-e RUSTFS_CONSOLE_ADDRESS=":9001" \
 	-e RUSTFS_CONSOLE_ENABLE=true \
 	-e RUSTFS_OBS_LOGGER_LEVEL=error \
-	-e RUSTFS_OBS_LOG_DIRECTORY="/var/log/rustfs/" \
+	-e RUSTFS_OBS_LOG_DIRECTORY="/logs" \
 	docker.io/rustfs/rustfs:<target-version> \
 	/data
 ```
-
 继续之前验证替换结果：
 
 ```bash
@@ -113,7 +112,6 @@ curl -fsS http://localhost:9000/health/ready
 docker compose config > docker-compose.resolved.yaml
 docker compose images rustfs
 ```
-
 将 `rustfs` 服务更改为明确的目标镜像标签，同时保持其卷、环境变量、端口和命令不变：
 
 ```yaml title="docker-compose.yml"
@@ -121,7 +119,6 @@ services:
 	rustfs:
 		image: rustfs/rustfs:<target-version>
 ```
-
 验证文件，拉取目标镜像，并仅重新创建 RustFS 服务。`--no-deps` 会让可选的可观测性服务继续运行：
 
 ```bash
@@ -129,7 +126,6 @@ docker compose config --quiet
 docker compose pull rustfs
 docker compose up -d --no-deps rustfs
 ```
-
 检查服务和 RustFS 就绪端点：
 
 ```bash
@@ -137,7 +133,6 @@ docker compose ps rustfs
 docker compose logs --tail=100 rustfs
 curl -fsS http://localhost:9000/health/ready
 ```
-
 如果 RustFS 与 `observability` profile 一起启动，RustFS 服务仍使用相同的命令升级。请根据各组件的发行说明分别升级可观测性镜像。
 
 ## 升级多节点部署
@@ -157,7 +152,6 @@ docker compose pull rustfs
 docker compose up -d --no-deps rustfs
 curl -fsS http://localhost:9000/health/ready
 ```
-
 在多节点部署中，请一次回滚一个节点，并等待其就绪后再继续。
 
 ## 后续步骤

--- a/public/_redirects
+++ b/public/_redirects
@@ -37,6 +37,8 @@
 /en/installation/checklists/network-checklists /en/installation/requirement/checklists/network-checklists 301
 /en/installation/checklists/security-checklists /en/installation/requirement/checklists/security-checklists 301
 /en/installation/checklists/software-checklists /en/installation/requirement/checklists/software-checklists 301
+/installation /en/installation 301
+/installation/ /en/installation 301
 /installation/docker /en/installation/container/docker 301
 /installation/docker/ /en/installation/container/docker 301
 /features/logging /en/operations/observability 301


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the Docker install examples reported in rustfs/rustfs#6844.

## Problem

The official `rustfs/rustfs` image runs as non-root `rustfs` (`10001:10001`) and sets `RUSTFS_OBS_LOG_DIRECTORY=/logs` in the Dockerfile. The published container docs copied the Linux package path `/var/log/rustfs/`. The entrypoint then tries `mkdir -p /var/log/rustfs/` and fails with `Permission denied`.

Bind-mounted host directories also need ownership `10001:10001`. Named volumes at `/data` and `/logs` inherit that ownership from the image.

## Changes

English guides (source of truth):

- Docker and Podman install: persist `/logs`, set `RUSTFS_OBS_LOG_DIRECTORY=/logs`, document bind-mount `chown 10001:10001`.
- Container overview, container upgrade, reverse-proxy and Iceberg/Milvus Compose snippets: same log path.
- Environment-variable and observability notes: image default is `/logs`; Linux packages still use `/var/log/rustfs/`.
- Redirect `/installation` and `/installation/` to `/en/installation`.

Locale files (`de`/`fr`/`ja`/`zh`): command blocks only, so `docs:check` fence parity passes. No translated prose was rewritten.

Linux systemd examples that create `/var/log/rustfs/` on the host are unchanged.

## Verification

- Commands match the upstream Dockerfile (`USER rustfs`, `ENV RUSTFS_OBS_LOG_DIRECTORY=/logs`) and the README Docker Quick Start.
- `npm run docs:check` — pass
- `npm run build` — pass (`2415 files generated`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e93a6322-137a-4c0a-bffc-80c17436776e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e93a6322-137a-4c0a-bffc-80c17436776e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

