### PR TITLE
fix: 301 redirect locale-less docs URLs to /en

### DIFF
--- a/scripts/add-language-redirects.mjs
+++ b/scripts/add-language-redirects.mjs
@@ -3,13 +3,19 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { collectLanguageRedirects } from './language-redirects.mjs';
+import { collectLanguageRedirects, collectPageRedirects } from './language-redirects.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_INDEX = path.join(ROOT, 'public', 'index.html');
 const OUTPUT_INDEX = path.join(ROOT, 'dist', 'public', 'index.html');
 const OUTPUT_REDIRECTS = path.join(ROOT, 'dist', 'public', '_redirects');
 const rules = collectLanguageRedirects();
+
+// Locale-less URLs fall through to the English page. Legacy rules stay first so
+// they keep winning, and page rules only fill the gaps.
+for (const [source, target] of collectPageRedirects()) {
+  if (!rules.has(source)) rules.set(source, target);
+}
 
 const output = [...rules].map(([source, target]) => `${source} ${target}`).join('\n');
 fs.copyFileSync(SOURCE_INDEX, OUTPUT_INDEX);

--- a/scripts/language-redirects.mjs
+++ b/scripts/language-redirects.mjs
@@ -4,6 +4,11 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_REDIRECTS = path.join(ROOT, 'public', '_redirects');
+const DEFAULT_LOCALE = 'en';
+const LOCALE_DIR = path.join(ROOT, 'dist', 'public', DEFAULT_LOCALE);
+// Generated pages that must keep their current behaviour: `/` serves the
+// language chooser and `/404` is the Cloudflare Pages error page.
+const SKIPPED_PAGES = new Set(['/404']);
 
 /** @returns {Map<string, string>} */
 export function collectLanguageRedirects() {
@@ -22,6 +27,47 @@ export function collectLanguageRedirects() {
     // Keep only base rules in _redirects to stay below Cloudflare's 100 dynamic rule limit.
     // Locale-aware variants are resolved at runtime by worker.mjs.
     rules.set(source, `${target} ${status}`);
+  }
+
+  return rules;
+}
+
+/** @param {string} dir @param {string[]} segments @returns {string[]} */
+function listPagePaths(dir, segments) {
+  /** @type {string[]} */
+  const pages = [];
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const nested = [...segments, entry.name];
+    if (fs.existsSync(path.join(dir, entry.name, 'index.html'))) {
+      pages.push(`/${nested.join('/')}`);
+    }
+
+    pages.push(...listPagePaths(path.join(dir, entry.name), nested));
+  }
+
+  return pages;
+}
+
+/**
+ * Static 301 rules for every English page, so a locale-less URL such as
+ * `/installation` resolves to `/en/installation` instead of returning 404.
+ * These are static (no splat), so they stay well clear of Cloudflare's
+ * 100 dynamic rule limit — Pages allows 2,000 static rules.
+ *
+ * @returns {Map<string, string>}
+ */
+export function collectPageRedirects() {
+  /** @type {Map<string, string>} */
+  const rules = new Map();
+
+  if (!fs.existsSync(LOCALE_DIR)) return rules;
+
+  for (const page of listPagePaths(LOCALE_DIR, [])) {
+    if (SKIPPED_PAGES.has(page)) continue;
+    rules.set(page, `/${DEFAULT_LOCALE}${page} 301`);
   }
 
   return rules;


### PR DESCRIPTION
## Problem

`https://docs.rustfs.com/installation` returns **404** instead of 301-redirecting to `/en/installation`. Same for every other locale-less page path:

```
/installation      404
/installation/     404
/operations        404
/reference         404
/developer/sdk     404
/management        301 -> /en/administration   (works: has an explicit rule)
/en/installation   200
```

## Root cause

`public/_redirects` is a hand-maintained whitelist of *legacy URL remaps* only. It has `/installation/docker` and `/installation/checklists`, but never `/installation` — and no generic "locale-less path → `/en/…`" fallback exists. This is a missing rule, not a broken 301.

Two pieces that look like they would cover it don't:

- `worker.mjs`'s locale fallback only fires for paths **already** prefixed with `/en/` (the opposite direction). In any case the Worker is **not live** — the site is served by Cloudflare Pages, which honors `_redirects` natively. Proof: `/en/management` returns 404 even though the Worker's en-fallback should 301 it.
- `public/language-redirect.js` bails out for any path other than `/` and `/index.html`, so it never helps deep links.

## Fix

Generate a static 301 for every built English page and append it **after** the legacy rules, so hand-maintained remaps keep winning on conflicts.

- `scripts/language-redirects.mjs` — new `collectPageRedirects()` walks `dist/public/en` for `index.html` and emits `/<page> /en/<page> 301`, skipping `/` (language chooser) and `/404` (Pages error page).
- `scripts/add-language-redirects.mjs` — appends those rules, skipping any source already covered by a legacy rule.

## Rule budget

Static rules (no splat), so they stay clear of Cloudflare Pages' **100 dynamic** limit and fit easily in the **2,000 static** limit:

| | before | after |
|---|---|---|
| static | 53 | 172 |
| dynamic | 3 | 3 |
| total | 56 | 175 |

56 legacy + 119 generated = 175.

## Verification

- Idempotent across runs.
- Zero duplicate sources.
- All 175 targets resolve to a real `dist/public/<target>/index.html`.
- Degrades gracefully to the 56 legacy rules when `dist/public/en` is absent.
- `/` still serves the language chooser; `/404` untouched.

Not run end-to-end: `npm run build` also invokes `scripts/sync-algolia.mjs`, which needs Algolia secrets. The redirect script was run directly against an existing `dist/`.
