### PR TITLE
fix: keep _redirects static rules before wildcard rules

### DIFF
--- a/scripts/add-language-redirects.mjs
+++ b/scripts/add-language-redirects.mjs
@@ -17,7 +17,18 @@ for (const [source, target] of collectPageRedirects()) {
   if (!rules.has(source)) rules.set(source, target);
 }
 
-const output = [...rules].map(([source, target]) => `${source} ${target}`).join('\n');
+// Cloudflare Workers static assets counts every rule at or after the first
+// wildcard rule against the 100-rule dynamic budget, so the file must stay
+// static-first: exact rules keep their precedence, and the legacy splat rules
+// move to the end where they consume the dynamic budget on their own.
+const isDynamic = (source) => source.includes('*');
+const entries = [...rules];
+const ordered = [
+  ...entries.filter(([source]) => !isDynamic(source)),
+  ...entries.filter(([source]) => isDynamic(source)),
+];
+
+const output = ordered.map(([source, target]) => `${source} ${target}`).join('\n');
 fs.copyFileSync(SOURCE_INDEX, OUTPUT_INDEX);
 fs.writeFileSync(OUTPUT_REDIRECTS, `${output}\n`);
 console.log(`language redirects: wrote the language entry page and ${rules.size} Cloudflare rules`);


### PR DESCRIPTION
## Problem

`wrangler deploy` fails after the locale-less 301 generation (#136) with:

```text
Invalid _redirects configuration:
Line 104: Maximum number of dynamic _redirects rules limit of 100 exceeded [code: 100324]
```

Cloudflare Workers static assets counts **every rule at or after the first wildcard rule** against the 100-rule dynamic budget. The generated `_redirects` kept the legacy splat rules (`/management/*`, `/administration/iam/*`, `/administration/security/encryption/*`) at the top, so all 119 generated page rules after them were treated as dynamic.

## Fix

`scripts/add-language-redirects.mjs` now emits rules **static-first, wildcard-last**: the 172 exact rules keep their precedence, and the 3 splat rules move to the end where they consume the dynamic budget alone.

Verified output (`dist/public/_redirects`, 175 rules):

```text
104:/installation /en/installation 301   (static section)
173:/management/* /en/administration/:splat 301
174:/administration/iam/* /en/security-compliance/iam/:splat 301
175:/administration/security/encryption/* /en/security-compliance/encryption/:splat 301
```

## Validation

- `node scripts/add-language-redirects.mjs` regenerates the file with the corrected ordering.
- Dynamic-rule count after the first splat: 3 (within the 100 limit).
