### PR TITLE
docs(iam): clarify readonly bucket listing permissions

### DIFF
--- a/content/de/security-compliance/iam/policies.md
+++ b/content/de/security-compliance/iam/policies.md
@@ -179,6 +179,6 @@ RustFS defines five built-in policies that can be attached without creating them
 
 :::warning
 
-The built-in `readonly` policy is intentionally minimal — it does not include `s3:ListBucket` or `s3:ListAllMyBuckets`. Users with only `readonly` can fetch objects by key but cannot browse buckets. Create a custom policy if listing is needed.
+Die integrierte Richtlinie `readonly` enthält weder `s3:ListBucket` noch `s3:ListAllMyBuckets`. Mit der Berechtigung `s3:GetBucketLocation` können Sie Bucket-Namen in RustFS sehen; mit `s3:GetObject` können Sie Objekte über einen bekannten Objektschlüssel abrufen. Um Objekte in einem Bucket aufzulisten, fügen Sie eine benutzerdefinierte Richtlinie hinzu, die `s3:ListBucket` für diesen Bucket gewährt.
 
 :::

--- a/content/en/security-compliance/iam/policies.md
+++ b/content/en/security-compliance/iam/policies.md
@@ -179,6 +179,6 @@ RustFS defines five built-in policies that can be attached without creating them
 
 :::warning
 
-The built-in `readonly` policy is intentionally minimal — it does not include `s3:ListBucket` or `s3:ListAllMyBuckets`. Users with only `readonly` can fetch objects by key but cannot browse buckets. Create a custom policy if listing is needed.
+The built-in `readonly` policy does not include `s3:ListBucket` or `s3:ListAllMyBuckets`. Its `s3:GetBucketLocation` permission allows you to see bucket names in RustFS, and `s3:GetObject` allows you to retrieve objects by a known key. To list objects within a bucket, add a custom policy granting `s3:ListBucket` on that bucket.
 
 :::

--- a/content/fr/security-compliance/iam/policies.md
+++ b/content/fr/security-compliance/iam/policies.md
@@ -179,6 +179,6 @@ RustFS defines five built-in policies that can be attached without creating them
 
 :::warning
 
-The built-in `readonly` policy is intentionally minimal — it does not include `s3:ListBucket` or `s3:ListAllMyBuckets`. Users with only `readonly` can fetch objects by key but cannot browse buckets. Create a custom policy if listing is needed.
+La politique intégrée `readonly` ne comprend ni `s3:ListBucket` ni `s3:ListAllMyBuckets`. L’autorisation `s3:GetBucketLocation` vous permet de voir les noms des compartiments dans RustFS, et `s3:GetObject` vous permet de récupérer des objets dont vous connaissez la clé. Pour lister les objets d’un compartiment, ajoutez une politique personnalisée accordant `s3:ListBucket` sur ce compartiment.
 
 :::

--- a/content/ja/security-compliance/iam/policies.md
+++ b/content/ja/security-compliance/iam/policies.md
@@ -179,6 +179,6 @@ RustFS defines five built-in policies that can be attached without creating them
 
 :::warning
 
-The built-in `readonly` policy is intentionally minimal — it does not include `s3:ListBucket` or `s3:ListAllMyBuckets`. Users with only `readonly` can fetch objects by key but cannot browse buckets. Create a custom policy if listing is needed.
+組み込みの `readonly` ポリシーには、`s3:ListBucket` と `s3:ListAllMyBuckets` は含まれません。このポリシーの `s3:GetBucketLocation` 権限により RustFS でバケット名を確認でき、`s3:GetObject` 権限により既知のオブジェクトキーを指定してオブジェクトを取得できます。バケット内のオブジェクトを一覧表示するには、そのバケットに対する `s3:ListBucket` 権限を付与するカスタムポリシーを追加します。
 
 :::

--- a/content/zh/security-compliance/iam/policies.md
+++ b/content/zh/security-compliance/iam/policies.md
@@ -179,6 +179,6 @@ RustFS 定义了五个内置策略，无需预先创建即可附加：
 
 :::warning
 
-内置 `readonly` 策略有意保持最小权限，不包括 `s3:ListBucket` 或 `s3:ListAllMyBuckets`。仅有 `readonly` 权限的用户可以按键获取对象，但不能浏览存储桶。如需列出内容，请创建自定义策略。
+内置 `readonly` 策略不包含 `s3:ListBucket` 或 `s3:ListAllMyBuckets`。其中的 `s3:GetBucketLocation` 权限允许你在 RustFS 中看到存储桶名称，`s3:GetObject` 权限允许你通过已知的对象键读取对象。如需列出存储桶内的对象，请添加自定义策略，授予针对该存储桶的 `s3:ListBucket` 权限。
 
 :::


### PR DESCRIPTION
## Summary

The built-in `readonly` policy permits bucket-name discovery through `s3:GetBucketLocation`, while listing objects inside a bucket requires `s3:ListBucket`. Replace the ambiguous "cannot browse buckets" warning with this distinction and explain how to grant object-listing access.

Update only the corresponding paragraph in `content/en`, `content/zh`, `content/de`, `content/fr`, and `content/ja`.

## Validation

- `git diff --check` — passed.
- `npm run docs:check` — passed for all 600 pages.
- `env -u ALGOLIA_ADMIN_API_KEY npm run build` — passed; verified the corrected paragraph in the generated HTML for all five locales. Algolia sync was skipped.
- `npm run types:check` — fails on existing implicit-any errors in `scripts/add-language-redirects.mjs` and `worker.mjs`. These files, the type configuration, and dependency manifests match `main`.
- `node .agents/skills/localize-rustfs-docs/scripts/audit-locales.mjs --locales zh,de,fr,ja --json` — remains blocked by existing untranslated content. Before: 362 errors and 39 warnings. After: 359 errors and 48 warnings; translating the three affected English-only paragraphs replaces three whole-file errors with nine warnings about the unchanged remainder of those pages.

## Implementation references

Verified against `rustfs/rustfs` at `72e85210f136da936b27f83faf4a4f0054f1bb32`:

- [Built-in readonly permissions](https://github.com/rustfs/rustfs/blob/72e85210f136da936b27f83faf4a4f0054f1bb32/crates/policy/src/policy/policy.rs#L440-L467).
- [Bucket-list filtering through ListBucket or GetBucketLocation](https://github.com/rustfs/rustfs/blob/72e85210f136da936b27f83faf4a4f0054f1bb32/rustfs/src/app/bucket_usecase.rs#L1531-L1544).
- [ListObjectsV2 requires ListBucket](https://github.com/rustfs/rustfs/blob/72e85210f136da936b27f83faf4a4f0054f1bb32/rustfs/src/storage/access.rs#L2667-L2675).
